### PR TITLE
Adding Ether Alley store functionality to Core API

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -39,7 +39,7 @@ type BadgeType = string
 const (
 	NON_FUNGIBLE_TOKEN BadgeType = "non_fungible_tokens"
 	FUNGIBLE_TOKEN     BadgeType = "fungible_tokens"
-	STATISTICS                   = "statistics"
+	STATISTICS         BadgeType = "statistics"
 )
 
 type AchievementType = string
@@ -54,22 +54,9 @@ const (
 	ZERO_ADDRESS Address = "0x0000000000000000000000000000000000000000"
 )
 
-// testnet erc20 addresses
-const (
-	UNI_GOERLI  Address = "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984"
-	LINK_GOERLI Address = "0x14b7ba66139c234b1be9a157d4f8b985b8a7f762"
-	HEX_GOERLI  Address = "0x08249c12c66c76ea384cf851bb3e274a2bb1874a"
-	DAI_GOERLI  Address = "0x11fe4b6ae13d2a6055c8d9cf65c55bac32b5d844"
-	SHIB_GOERLI Address = "0xC5Ad32f66e0dd5FA75dB3FF839AB7783ce9f1a68"
-	CRO_GOERLI  Address = "0x014EB3F44A9687450459a219f47C154158fc62aD"
-)
+type TokenIds = string
 
-// mainnet erc20 addresses
 const (
-	UNI_MAINNET  Address = "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984"
-	LINK_MAINNET Address = "0x514910771af9ca656af840dff83e8264ecf986ca"
-	HEX_MAINNET  Address = "0x2b591e99afe9f32eaa6214f7b7629768c40eeb39"
-	DAI_MAINNET  Address = "0x6b175474e89094c44da98b954eedeac495271d0f"
-	SHIB_MAINNET Address = "0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE"
-	CRO_MAINNET  Address = "0xa0b73e1ff0b80914ab6fe0444e65848c4c34450b"
+	STORE_PREMIUM     TokenIds = "1"
+	STORE_BETA_TESTER TokenIds = "2"
 )

--- a/common/settings.go
+++ b/common/settings.go
@@ -32,29 +32,31 @@ type ISettings interface {
 	IPFSURI() string
 	TheGraphURI() string
 	TheGraphHostedURI() string
+	DefaultTokenAddresses() []string
 }
 
 type settings struct {
-	hostname          string
-	instanceID        string
-	env               string
-	port              string
-	redisAddr         string
-	redisDB           string
-	redisPassword     string
-	mongoURI          string
-	mongoDB           string
-	storeBlockchain   string
-	storeAddress      string
-	storeImageURI     string
-	ethereumURI       string
-	polygonURI        string
-	arbitrumURI       string
-	optimismURI       string
-	ensMetadataURI    string
-	ipfsURI           string
-	theGraphURI       string
-	theGraphHostedURI string
+	hostname              string
+	instanceID            string
+	env                   string
+	port                  string
+	redisAddr             string
+	redisDB               string
+	redisPassword         string
+	mongoURI              string
+	mongoDB               string
+	storeBlockchain       string
+	storeAddress          string
+	storeImageURI         string
+	ethereumURI           string
+	polygonURI            string
+	arbitrumURI           string
+	optimismURI           string
+	ensMetadataURI        string
+	ipfsURI               string
+	theGraphURI           string
+	theGraphHostedURI     string
+	defaultTokenAddresses string
 }
 
 func NewSettings() ISettings {
@@ -79,26 +81,27 @@ func NewSettings() ISettings {
 	instanceID = instanceID[0:10]
 
 	return &settings{
-		hostname:          hostname,
-		instanceID:        instanceID,
-		env:               os.Getenv("ENV"),
-		port:              os.Getenv("PORT"),
-		redisAddr:         os.Getenv("REDIS_ADDR"),
-		redisPassword:     os.Getenv("REDIS_PASSWORD"),
-		redisDB:           os.Getenv("REDIS_DB"),
-		mongoURI:          os.Getenv("MONGO_URI"),
-		mongoDB:           os.Getenv("MONGO_DB"),
-		storeBlockchain:   os.Getenv("STORE_BLOCKCHAIN"),
-		storeAddress:      os.Getenv("STORE_ADDRESS"),
-		storeImageURI:     os.Getenv("STORE_IMAGE_URI"),
-		ethereumURI:       os.Getenv("ETHEREUM_URI"),
-		polygonURI:        os.Getenv("POLYGON_URI"),
-		arbitrumURI:       os.Getenv("ARBITRUM_URI"),
-		optimismURI:       os.Getenv("OPTIMISM_URI"),
-		ensMetadataURI:    os.Getenv("ENS_METADATA_URI"),
-		ipfsURI:           os.Getenv("IPFS_URI"),
-		theGraphURI:       os.Getenv("THE_GRAPH_URI"),
-		theGraphHostedURI: os.Getenv("THE_GRAPH_HOSTED_URI"),
+		hostname:              hostname,
+		instanceID:            instanceID,
+		env:                   os.Getenv("ENV"),
+		port:                  os.Getenv("PORT"),
+		redisAddr:             os.Getenv("REDIS_ADDR"),
+		redisPassword:         os.Getenv("REDIS_PASSWORD"),
+		redisDB:               os.Getenv("REDIS_DB"),
+		mongoURI:              os.Getenv("MONGO_URI"),
+		mongoDB:               os.Getenv("MONGO_DB"),
+		storeBlockchain:       os.Getenv("STORE_BLOCKCHAIN"),
+		storeAddress:          os.Getenv("STORE_ADDRESS"),
+		storeImageURI:         os.Getenv("STORE_IMAGE_URI"),
+		ethereumURI:           os.Getenv("ETHEREUM_URI"),
+		polygonURI:            os.Getenv("POLYGON_URI"),
+		arbitrumURI:           os.Getenv("ARBITRUM_URI"),
+		optimismURI:           os.Getenv("OPTIMISM_URI"),
+		ensMetadataURI:        os.Getenv("ENS_METADATA_URI"),
+		ipfsURI:               os.Getenv("IPFS_URI"),
+		theGraphURI:           os.Getenv("THE_GRAPH_URI"),
+		theGraphHostedURI:     os.Getenv("THE_GRAPH_HOSTED_URI"),
+		defaultTokenAddresses: os.Getenv("DEFAULT_TOKEN_ADDRESSES"),
 	}
 }
 
@@ -190,4 +193,8 @@ func (s *settings) TheGraphURI() string {
 
 func (s *settings) TheGraphHostedURI() string {
 	return s.theGraphHostedURI
+}
+
+func (s *settings) DefaultTokenAddresses() []string {
+	return strings.Split(s.defaultTokenAddresses, ",")
 }

--- a/common/settings.go
+++ b/common/settings.go
@@ -21,6 +21,9 @@ type ISettings interface {
 	CachePassword() string
 	DatabaseURI() string
 	Database() string
+	StoreBlockchain() string
+	StoreAddress() string
+	StoreImageURI() string
 	EthereumURI() string
 	PolygonURI() string
 	ArbitrumURI() string
@@ -41,6 +44,9 @@ type settings struct {
 	redisPassword     string
 	mongoURI          string
 	mongoDB           string
+	storeBlockchain   string
+	storeAddress      string
+	storeImageURI     string
 	ethereumURI       string
 	polygonURI        string
 	arbitrumURI       string
@@ -82,6 +88,9 @@ func NewSettings() ISettings {
 		redisDB:           os.Getenv("REDIS_DB"),
 		mongoURI:          os.Getenv("MONGO_URI"),
 		mongoDB:           os.Getenv("MONGO_DB"),
+		storeBlockchain:   os.Getenv("STORE_BLOCKCHAIN"),
+		storeAddress:      os.Getenv("STORE_ADDRESS"),
+		storeImageURI:     os.Getenv("STORE_IMAGE_URI"),
 		ethereumURI:       os.Getenv("ETHEREUM_URI"),
 		polygonURI:        os.Getenv("POLYGON_URI"),
 		arbitrumURI:       os.Getenv("ARBITRUM_URI"),
@@ -137,6 +146,18 @@ func (s *settings) DatabaseURI() string {
 
 func (s *settings) Database() string {
 	return s.mongoDB
+}
+
+func (s *settings) StoreBlockchain() string {
+	return s.storeBlockchain
+}
+
+func (s *settings) StoreAddress() string {
+	return s.storeAddress
+}
+
+func (s *settings) StoreImageURI() string {
+	return s.storeImageURI
 }
 
 func (s *settings) EthereumURI() string {

--- a/controllers/http/ens.go
+++ b/controllers/http/ens.go
@@ -9,11 +9,11 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-// the address param of the route could be either an ens name or an address
-func (hc *HttpController) resolveAddr(next http.Handler) http.Handler {
+func (hc *HttpController) resolveAddressRoute(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
+		// the address param of the route could be either an ens name or an address
 		address, err := hc.resolveAddress(ctx, &usecases.ResolveAddressInput{
 			Value: chi.URLParam(r, "address"),
 		})

--- a/controllers/http/http.go
+++ b/controllers/http/http.go
@@ -28,6 +28,8 @@ type HttpController struct {
 	getInteraction      usecases.IGetInteractionUseCase
 	recordProfileView   usecases.IRecordProfileViewUseCase
 	getTopProfiles      usecases.IGetTopProfilesUseCase
+	getListingMetadata  usecases.IGetListingMetadataUseCase
+	getListings         usecases.IGetListingsUseCase
 }
 
 func NewHttpController(
@@ -45,6 +47,8 @@ func NewHttpController(
 	getInteraction usecases.IGetInteractionUseCase,
 	recordProfileView usecases.IRecordProfileViewUseCase,
 	getTopProfiles usecases.IGetTopProfilesUseCase,
+	getListingMetadata usecases.IGetListingMetadataUseCase,
+	getListings usecases.IGetListingsUseCase,
 ) *HttpController {
 	return &HttpController{
 		settings,
@@ -61,6 +65,8 @@ func NewHttpController(
 		getInteraction,
 		recordProfileView,
 		getTopProfiles,
+		getListingMetadata,
+		getListings,
 	}
 }
 
@@ -112,6 +118,11 @@ func (hc *HttpController) Start() error {
 	r.Route("/transactions", func(r chi.Router) {
 		r.Use(hc.parseTransaction)
 		r.Get("/interaction", hc.getInteractionRoute)
+	})
+
+	r.Route("/listings", func(r chi.Router) {
+		r.Get("/", hc.getListingsRoute)
+		r.Get("/metadata/{tokenid}", hc.getMetadataByIdRoute)
 	})
 
 	port := hc.settings.Port()

--- a/controllers/http/http.go
+++ b/controllers/http/http.go
@@ -30,6 +30,7 @@ type HttpController struct {
 	getTopProfiles      usecases.IGetTopProfilesUseCase
 	getListingMetadata  usecases.IGetListingMetadataUseCase
 	getListings         usecases.IGetListingsUseCase
+	refreshProfile      usecases.IRefreshProfileUseCase
 }
 
 func NewHttpController(
@@ -49,6 +50,7 @@ func NewHttpController(
 	getTopProfiles usecases.IGetTopProfilesUseCase,
 	getListingMetadata usecases.IGetListingMetadataUseCase,
 	getListings usecases.IGetListingsUseCase,
+	refreshProfile usecases.IRefreshProfileUseCase,
 ) *HttpController {
 	return &HttpController{
 		settings,
@@ -67,6 +69,7 @@ func NewHttpController(
 		getTopProfiles,
 		getListingMetadata,
 		getListings,
+		refreshProfile,
 	}
 }
 
@@ -97,14 +100,15 @@ func (hc *HttpController) Start() error {
 		r.Get("/top", hc.getTopProfilesRoute)
 
 		r.Route("/{address}", func(r chi.Router) {
-			r.Use(hc.resolveAddr)
+			r.Use(hc.resolveAddressRoute)
 			r.With(hc.recordProfileViewMiddleware).Get("/", hc.getProfileByAddressRoute)
 			r.With(hc.authenticate).Put("/", hc.saveProfileRoute)
+			r.Get("/refresh", hc.refreshProfileRoute)
 		})
 	})
 
 	r.Route("/challenges/{address}", func(r chi.Router) {
-		r.Use(hc.resolveAddr)
+		r.Use(hc.resolveAddressRoute)
 		r.Get("/", hc.getChallengeRoute)
 	})
 

--- a/controllers/http/listing.go
+++ b/controllers/http/listing.go
@@ -1,0 +1,45 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/etheralley/etheralley-core-api/usecases"
+	"github.com/go-chi/chi/v5"
+)
+
+func (hc *HttpController) getMetadataByIdRoute(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	metadata, err := hc.getListingMetadata(ctx, &usecases.GetListingMetadataInput{
+		TokenId: chi.URLParam(r, "tokenid"),
+	})
+
+	if err != nil {
+		hc.presenter.PresentBadRequest(w, r, err)
+		return
+	}
+
+	hc.presenter.PresentListingMetadata(w, r, metadata)
+}
+
+func (hc *HttpController) getListingsRoute(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	input := &usecases.GetListingsInput{}
+	err := json.NewDecoder(r.Body).Decode(input)
+
+	if err != nil {
+		hc.presenter.PresentBadRequest(w, r, err)
+		return
+	}
+
+	listings, err := hc.getListings(ctx, input)
+
+	if err != nil {
+		hc.presenter.PresentBadRequest(w, r, err)
+		return
+	}
+
+	hc.presenter.PresentListings(w, r, listings)
+}

--- a/controllers/http/profile.go
+++ b/controllers/http/profile.go
@@ -77,3 +77,19 @@ func (hc *HttpController) getTopProfilesRoute(w http.ResponseWriter, r *http.Req
 
 	hc.presenter.PresentTopProfiles(w, r, profiles)
 }
+
+func (hc *HttpController) refreshProfileRoute(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	address := ctx.Value(common.ContextKeyAddress).(string)
+
+	err := hc.refreshProfile(ctx, &usecases.RefreshProfileInput{
+		Address: address,
+	})
+
+	if err != nil {
+		hc.presenter.PresentBadRequest(w, r, err)
+		return
+	}
+
+	hc.presenter.PresentRefreshedProfile(w, r)
+}

--- a/entities/listing.go
+++ b/entities/listing.go
@@ -1,0 +1,16 @@
+package entities
+
+type Listing struct {
+	Contract *Contract
+	TokenId  string
+	Info     *ListingInfo
+	Metadata *NonFungibleMetadata
+}
+
+type ListingInfo struct {
+	Purchasable  bool
+	Transferable bool
+	Price        string
+	BalanceLimit string
+	SupplyLimit  string
+}

--- a/entities/profile.go
+++ b/entities/profile.go
@@ -3,6 +3,7 @@ package entities
 type Profile struct {
 	Address           string
 	ENSName           string
+	StoreAssets       *StoreAssets
 	DisplayConfig     *DisplayConfig // DisplayConfig can be nil
 	NonFungibleTokens *[]NonFungibleToken
 	FungibleTokens    *[]FungibleToken

--- a/entities/store_assets.go
+++ b/entities/store_assets.go
@@ -1,0 +1,6 @@
+package entities
+
+type StoreAssets struct {
+	Premium    bool
+	BetaTester bool
+}

--- a/gateways/ethereum/contracts/etherAlleyStore.go
+++ b/gateways/ethereum/contracts/etherAlleyStore.go
@@ -1,0 +1,1384 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package contracts
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+)
+
+// IEtherAlleyStoreTokenListing is an auto generated low-level Go binding around an user-defined struct.
+type IEtherAlleyStoreTokenListing struct {
+	Purchasable  bool
+	Transferable bool
+	Price        *big.Int
+	SupplyLimit  *big.Int
+	BalanceLimit *big.Int
+	Supply       *big.Int
+}
+
+// EtherAlleyStoreMetaData contains all meta data concerning the EtherAlleyStore contract.
+var EtherAlleyStoreMetaData = &bind.MetaData{
+	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"approved\",\"type\":\"bool\"}],\"name\":\"ApprovalForAll\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"purchasable\",\"type\":\"bool\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"transferable\",\"type\":\"bool\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"price\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"supplyLimit\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"balanceLimit\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"supply\",\"type\":\"uint256\"}],\"name\":\"ListingChange\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256[]\",\"name\":\"ids\",\"type\":\"uint256[]\"},{\"indexed\":false,\"internalType\":\"uint256[]\",\"name\":\"values\",\"type\":\"uint256[]\"}],\"name\":\"TransferBatch\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"TransferSingle\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"string\",\"name\":\"value\",\"type\":\"string\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"}],\"name\":\"URI\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"}],\"name\":\"balanceOf\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address[]\",\"name\":\"accounts\",\"type\":\"address[]\"},{\"internalType\":\"uint256[]\",\"name\":\"ids\",\"type\":\"uint256[]\"}],\"name\":\"balanceOfBatch\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"}],\"name\":\"getListing\",\"outputs\":[{\"components\":[{\"internalType\":\"bool\",\"name\":\"purchasable\",\"type\":\"bool\"},{\"internalType\":\"bool\",\"name\":\"transferable\",\"type\":\"bool\"},{\"internalType\":\"uint256\",\"name\":\"price\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"supplyLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"balanceLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"supply\",\"type\":\"uint256\"}],\"internalType\":\"structIEtherAlleyStore.TokenListing\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256[]\",\"name\":\"ids\",\"type\":\"uint256[]\"}],\"name\":\"getListingBatch\",\"outputs\":[{\"components\":[{\"internalType\":\"bool\",\"name\":\"purchasable\",\"type\":\"bool\"},{\"internalType\":\"bool\",\"name\":\"transferable\",\"type\":\"bool\"},{\"internalType\":\"uint256\",\"name\":\"price\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"supplyLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"balanceLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"supply\",\"type\":\"uint256\"}],\"internalType\":\"structIEtherAlleyStore.TokenListing[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"}],\"name\":\"isApprovedForAll\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"pause\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"purchase\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256[]\",\"name\":\"ids\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256[]\",\"name\":\"amounts\",\"type\":\"uint256[]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"purchaseBatch\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256[]\",\"name\":\"ids\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256[]\",\"name\":\"amounts\",\"type\":\"uint256[]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"safeBatchTransferFrom\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"safeTransferFrom\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"approved\",\"type\":\"bool\"}],\"name\":\"setApprovalForAll\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"},{\"internalType\":\"bool\",\"name\":\"purchasable\",\"type\":\"bool\"},{\"internalType\":\"bool\",\"name\":\"transferable\",\"type\":\"bool\"},{\"internalType\":\"uint256\",\"name\":\"price\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"supplyLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"balanceLimit\",\"type\":\"uint256\"}],\"name\":\"setListing\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"newuri\",\"type\":\"string\"}],\"name\":\"setURI\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"}],\"name\":\"supportsInterface\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"transferBalance\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"unpause\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"}],\"name\":\"uri\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+}
+
+// EtherAlleyStoreABI is the input ABI used to generate the binding from.
+// Deprecated: Use EtherAlleyStoreMetaData.ABI instead.
+var EtherAlleyStoreABI = EtherAlleyStoreMetaData.ABI
+
+// EtherAlleyStore is an auto generated Go binding around an Ethereum contract.
+type EtherAlleyStore struct {
+	EtherAlleyStoreCaller     // Read-only binding to the contract
+	EtherAlleyStoreTransactor // Write-only binding to the contract
+	EtherAlleyStoreFilterer   // Log filterer for contract events
+}
+
+// EtherAlleyStoreCaller is an auto generated read-only Go binding around an Ethereum contract.
+type EtherAlleyStoreCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// EtherAlleyStoreTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type EtherAlleyStoreTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// EtherAlleyStoreFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type EtherAlleyStoreFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// EtherAlleyStoreSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type EtherAlleyStoreSession struct {
+	Contract     *EtherAlleyStore  // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// EtherAlleyStoreCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type EtherAlleyStoreCallerSession struct {
+	Contract *EtherAlleyStoreCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts          // Call options to use throughout this session
+}
+
+// EtherAlleyStoreTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type EtherAlleyStoreTransactorSession struct {
+	Contract     *EtherAlleyStoreTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts          // Transaction auth options to use throughout this session
+}
+
+// EtherAlleyStoreRaw is an auto generated low-level Go binding around an Ethereum contract.
+type EtherAlleyStoreRaw struct {
+	Contract *EtherAlleyStore // Generic contract binding to access the raw methods on
+}
+
+// EtherAlleyStoreCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type EtherAlleyStoreCallerRaw struct {
+	Contract *EtherAlleyStoreCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// EtherAlleyStoreTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type EtherAlleyStoreTransactorRaw struct {
+	Contract *EtherAlleyStoreTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewEtherAlleyStore creates a new instance of EtherAlleyStore, bound to a specific deployed contract.
+func NewEtherAlleyStore(address common.Address, backend bind.ContractBackend) (*EtherAlleyStore, error) {
+	contract, err := bindEtherAlleyStore(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &EtherAlleyStore{EtherAlleyStoreCaller: EtherAlleyStoreCaller{contract: contract}, EtherAlleyStoreTransactor: EtherAlleyStoreTransactor{contract: contract}, EtherAlleyStoreFilterer: EtherAlleyStoreFilterer{contract: contract}}, nil
+}
+
+// NewEtherAlleyStoreCaller creates a new read-only instance of EtherAlleyStore, bound to a specific deployed contract.
+func NewEtherAlleyStoreCaller(address common.Address, caller bind.ContractCaller) (*EtherAlleyStoreCaller, error) {
+	contract, err := bindEtherAlleyStore(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &EtherAlleyStoreCaller{contract: contract}, nil
+}
+
+// NewEtherAlleyStoreTransactor creates a new write-only instance of EtherAlleyStore, bound to a specific deployed contract.
+func NewEtherAlleyStoreTransactor(address common.Address, transactor bind.ContractTransactor) (*EtherAlleyStoreTransactor, error) {
+	contract, err := bindEtherAlleyStore(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &EtherAlleyStoreTransactor{contract: contract}, nil
+}
+
+// NewEtherAlleyStoreFilterer creates a new log filterer instance of EtherAlleyStore, bound to a specific deployed contract.
+func NewEtherAlleyStoreFilterer(address common.Address, filterer bind.ContractFilterer) (*EtherAlleyStoreFilterer, error) {
+	contract, err := bindEtherAlleyStore(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &EtherAlleyStoreFilterer{contract: contract}, nil
+}
+
+// bindEtherAlleyStore binds a generic wrapper to an already deployed contract.
+func bindEtherAlleyStore(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(EtherAlleyStoreABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_EtherAlleyStore *EtherAlleyStoreRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _EtherAlleyStore.Contract.EtherAlleyStoreCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_EtherAlleyStore *EtherAlleyStoreRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _EtherAlleyStore.Contract.EtherAlleyStoreTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_EtherAlleyStore *EtherAlleyStoreRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _EtherAlleyStore.Contract.EtherAlleyStoreTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_EtherAlleyStore *EtherAlleyStoreCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _EtherAlleyStore.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_EtherAlleyStore *EtherAlleyStoreTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _EtherAlleyStore.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_EtherAlleyStore *EtherAlleyStoreTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _EtherAlleyStore.Contract.contract.Transact(opts, method, params...)
+}
+
+// BalanceOf is a free data retrieval call binding the contract method 0x00fdd58e.
+//
+// Solidity: function balanceOf(address account, uint256 id) view returns(uint256)
+func (_EtherAlleyStore *EtherAlleyStoreCaller) BalanceOf(opts *bind.CallOpts, account common.Address, id *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _EtherAlleyStore.contract.Call(opts, &out, "balanceOf", account, id)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// BalanceOf is a free data retrieval call binding the contract method 0x00fdd58e.
+//
+// Solidity: function balanceOf(address account, uint256 id) view returns(uint256)
+func (_EtherAlleyStore *EtherAlleyStoreSession) BalanceOf(account common.Address, id *big.Int) (*big.Int, error) {
+	return _EtherAlleyStore.Contract.BalanceOf(&_EtherAlleyStore.CallOpts, account, id)
+}
+
+// BalanceOf is a free data retrieval call binding the contract method 0x00fdd58e.
+//
+// Solidity: function balanceOf(address account, uint256 id) view returns(uint256)
+func (_EtherAlleyStore *EtherAlleyStoreCallerSession) BalanceOf(account common.Address, id *big.Int) (*big.Int, error) {
+	return _EtherAlleyStore.Contract.BalanceOf(&_EtherAlleyStore.CallOpts, account, id)
+}
+
+// BalanceOfBatch is a free data retrieval call binding the contract method 0x4e1273f4.
+//
+// Solidity: function balanceOfBatch(address[] accounts, uint256[] ids) view returns(uint256[])
+func (_EtherAlleyStore *EtherAlleyStoreCaller) BalanceOfBatch(opts *bind.CallOpts, accounts []common.Address, ids []*big.Int) ([]*big.Int, error) {
+	var out []interface{}
+	err := _EtherAlleyStore.contract.Call(opts, &out, "balanceOfBatch", accounts, ids)
+
+	if err != nil {
+		return *new([]*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]*big.Int)).(*[]*big.Int)
+
+	return out0, err
+
+}
+
+// BalanceOfBatch is a free data retrieval call binding the contract method 0x4e1273f4.
+//
+// Solidity: function balanceOfBatch(address[] accounts, uint256[] ids) view returns(uint256[])
+func (_EtherAlleyStore *EtherAlleyStoreSession) BalanceOfBatch(accounts []common.Address, ids []*big.Int) ([]*big.Int, error) {
+	return _EtherAlleyStore.Contract.BalanceOfBatch(&_EtherAlleyStore.CallOpts, accounts, ids)
+}
+
+// BalanceOfBatch is a free data retrieval call binding the contract method 0x4e1273f4.
+//
+// Solidity: function balanceOfBatch(address[] accounts, uint256[] ids) view returns(uint256[])
+func (_EtherAlleyStore *EtherAlleyStoreCallerSession) BalanceOfBatch(accounts []common.Address, ids []*big.Int) ([]*big.Int, error) {
+	return _EtherAlleyStore.Contract.BalanceOfBatch(&_EtherAlleyStore.CallOpts, accounts, ids)
+}
+
+// GetListing is a free data retrieval call binding the contract method 0x107a274a.
+//
+// Solidity: function getListing(uint256 id) view returns((bool,bool,uint256,uint256,uint256,uint256))
+func (_EtherAlleyStore *EtherAlleyStoreCaller) GetListing(opts *bind.CallOpts, id *big.Int) (IEtherAlleyStoreTokenListing, error) {
+	var out []interface{}
+	err := _EtherAlleyStore.contract.Call(opts, &out, "getListing", id)
+
+	if err != nil {
+		return *new(IEtherAlleyStoreTokenListing), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(IEtherAlleyStoreTokenListing)).(*IEtherAlleyStoreTokenListing)
+
+	return out0, err
+
+}
+
+// GetListing is a free data retrieval call binding the contract method 0x107a274a.
+//
+// Solidity: function getListing(uint256 id) view returns((bool,bool,uint256,uint256,uint256,uint256))
+func (_EtherAlleyStore *EtherAlleyStoreSession) GetListing(id *big.Int) (IEtherAlleyStoreTokenListing, error) {
+	return _EtherAlleyStore.Contract.GetListing(&_EtherAlleyStore.CallOpts, id)
+}
+
+// GetListing is a free data retrieval call binding the contract method 0x107a274a.
+//
+// Solidity: function getListing(uint256 id) view returns((bool,bool,uint256,uint256,uint256,uint256))
+func (_EtherAlleyStore *EtherAlleyStoreCallerSession) GetListing(id *big.Int) (IEtherAlleyStoreTokenListing, error) {
+	return _EtherAlleyStore.Contract.GetListing(&_EtherAlleyStore.CallOpts, id)
+}
+
+// GetListingBatch is a free data retrieval call binding the contract method 0x45384ec3.
+//
+// Solidity: function getListingBatch(uint256[] ids) view returns((bool,bool,uint256,uint256,uint256,uint256)[])
+func (_EtherAlleyStore *EtherAlleyStoreCaller) GetListingBatch(opts *bind.CallOpts, ids []*big.Int) ([]IEtherAlleyStoreTokenListing, error) {
+	var out []interface{}
+	err := _EtherAlleyStore.contract.Call(opts, &out, "getListingBatch", ids)
+
+	if err != nil {
+		return *new([]IEtherAlleyStoreTokenListing), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]IEtherAlleyStoreTokenListing)).(*[]IEtherAlleyStoreTokenListing)
+
+	return out0, err
+
+}
+
+// GetListingBatch is a free data retrieval call binding the contract method 0x45384ec3.
+//
+// Solidity: function getListingBatch(uint256[] ids) view returns((bool,bool,uint256,uint256,uint256,uint256)[])
+func (_EtherAlleyStore *EtherAlleyStoreSession) GetListingBatch(ids []*big.Int) ([]IEtherAlleyStoreTokenListing, error) {
+	return _EtherAlleyStore.Contract.GetListingBatch(&_EtherAlleyStore.CallOpts, ids)
+}
+
+// GetListingBatch is a free data retrieval call binding the contract method 0x45384ec3.
+//
+// Solidity: function getListingBatch(uint256[] ids) view returns((bool,bool,uint256,uint256,uint256,uint256)[])
+func (_EtherAlleyStore *EtherAlleyStoreCallerSession) GetListingBatch(ids []*big.Int) ([]IEtherAlleyStoreTokenListing, error) {
+	return _EtherAlleyStore.Contract.GetListingBatch(&_EtherAlleyStore.CallOpts, ids)
+}
+
+// IsApprovedForAll is a free data retrieval call binding the contract method 0xe985e9c5.
+//
+// Solidity: function isApprovedForAll(address account, address operator) view returns(bool)
+func (_EtherAlleyStore *EtherAlleyStoreCaller) IsApprovedForAll(opts *bind.CallOpts, account common.Address, operator common.Address) (bool, error) {
+	var out []interface{}
+	err := _EtherAlleyStore.contract.Call(opts, &out, "isApprovedForAll", account, operator)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsApprovedForAll is a free data retrieval call binding the contract method 0xe985e9c5.
+//
+// Solidity: function isApprovedForAll(address account, address operator) view returns(bool)
+func (_EtherAlleyStore *EtherAlleyStoreSession) IsApprovedForAll(account common.Address, operator common.Address) (bool, error) {
+	return _EtherAlleyStore.Contract.IsApprovedForAll(&_EtherAlleyStore.CallOpts, account, operator)
+}
+
+// IsApprovedForAll is a free data retrieval call binding the contract method 0xe985e9c5.
+//
+// Solidity: function isApprovedForAll(address account, address operator) view returns(bool)
+func (_EtherAlleyStore *EtherAlleyStoreCallerSession) IsApprovedForAll(account common.Address, operator common.Address) (bool, error) {
+	return _EtherAlleyStore.Contract.IsApprovedForAll(&_EtherAlleyStore.CallOpts, account, operator)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_EtherAlleyStore *EtherAlleyStoreCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _EtherAlleyStore.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_EtherAlleyStore *EtherAlleyStoreSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _EtherAlleyStore.Contract.SupportsInterface(&_EtherAlleyStore.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_EtherAlleyStore *EtherAlleyStoreCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _EtherAlleyStore.Contract.SupportsInterface(&_EtherAlleyStore.CallOpts, interfaceId)
+}
+
+// Uri is a free data retrieval call binding the contract method 0x0e89341c.
+//
+// Solidity: function uri(uint256 id) view returns(string)
+func (_EtherAlleyStore *EtherAlleyStoreCaller) Uri(opts *bind.CallOpts, id *big.Int) (string, error) {
+	var out []interface{}
+	err := _EtherAlleyStore.contract.Call(opts, &out, "uri", id)
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// Uri is a free data retrieval call binding the contract method 0x0e89341c.
+//
+// Solidity: function uri(uint256 id) view returns(string)
+func (_EtherAlleyStore *EtherAlleyStoreSession) Uri(id *big.Int) (string, error) {
+	return _EtherAlleyStore.Contract.Uri(&_EtherAlleyStore.CallOpts, id)
+}
+
+// Uri is a free data retrieval call binding the contract method 0x0e89341c.
+//
+// Solidity: function uri(uint256 id) view returns(string)
+func (_EtherAlleyStore *EtherAlleyStoreCallerSession) Uri(id *big.Int) (string, error) {
+	return _EtherAlleyStore.Contract.Uri(&_EtherAlleyStore.CallOpts, id)
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_EtherAlleyStore *EtherAlleyStoreTransactor) Pause(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _EtherAlleyStore.contract.Transact(opts, "pause")
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_EtherAlleyStore *EtherAlleyStoreSession) Pause() (*types.Transaction, error) {
+	return _EtherAlleyStore.Contract.Pause(&_EtherAlleyStore.TransactOpts)
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_EtherAlleyStore *EtherAlleyStoreTransactorSession) Pause() (*types.Transaction, error) {
+	return _EtherAlleyStore.Contract.Pause(&_EtherAlleyStore.TransactOpts)
+}
+
+// Purchase is a paid mutator transaction binding the contract method 0xeea3ea3f.
+//
+// Solidity: function purchase(address account, uint256 id, uint256 amount, bytes data) payable returns()
+func (_EtherAlleyStore *EtherAlleyStoreTransactor) Purchase(opts *bind.TransactOpts, account common.Address, id *big.Int, amount *big.Int, data []byte) (*types.Transaction, error) {
+	return _EtherAlleyStore.contract.Transact(opts, "purchase", account, id, amount, data)
+}
+
+// Purchase is a paid mutator transaction binding the contract method 0xeea3ea3f.
+//
+// Solidity: function purchase(address account, uint256 id, uint256 amount, bytes data) payable returns()
+func (_EtherAlleyStore *EtherAlleyStoreSession) Purchase(account common.Address, id *big.Int, amount *big.Int, data []byte) (*types.Transaction, error) {
+	return _EtherAlleyStore.Contract.Purchase(&_EtherAlleyStore.TransactOpts, account, id, amount, data)
+}
+
+// Purchase is a paid mutator transaction binding the contract method 0xeea3ea3f.
+//
+// Solidity: function purchase(address account, uint256 id, uint256 amount, bytes data) payable returns()
+func (_EtherAlleyStore *EtherAlleyStoreTransactorSession) Purchase(account common.Address, id *big.Int, amount *big.Int, data []byte) (*types.Transaction, error) {
+	return _EtherAlleyStore.Contract.Purchase(&_EtherAlleyStore.TransactOpts, account, id, amount, data)
+}
+
+// PurchaseBatch is a paid mutator transaction binding the contract method 0x8b2be628.
+//
+// Solidity: function purchaseBatch(address to, uint256[] ids, uint256[] amounts, bytes data) payable returns()
+func (_EtherAlleyStore *EtherAlleyStoreTransactor) PurchaseBatch(opts *bind.TransactOpts, to common.Address, ids []*big.Int, amounts []*big.Int, data []byte) (*types.Transaction, error) {
+	return _EtherAlleyStore.contract.Transact(opts, "purchaseBatch", to, ids, amounts, data)
+}
+
+// PurchaseBatch is a paid mutator transaction binding the contract method 0x8b2be628.
+//
+// Solidity: function purchaseBatch(address to, uint256[] ids, uint256[] amounts, bytes data) payable returns()
+func (_EtherAlleyStore *EtherAlleyStoreSession) PurchaseBatch(to common.Address, ids []*big.Int, amounts []*big.Int, data []byte) (*types.Transaction, error) {
+	return _EtherAlleyStore.Contract.PurchaseBatch(&_EtherAlleyStore.TransactOpts, to, ids, amounts, data)
+}
+
+// PurchaseBatch is a paid mutator transaction binding the contract method 0x8b2be628.
+//
+// Solidity: function purchaseBatch(address to, uint256[] ids, uint256[] amounts, bytes data) payable returns()
+func (_EtherAlleyStore *EtherAlleyStoreTransactorSession) PurchaseBatch(to common.Address, ids []*big.Int, amounts []*big.Int, data []byte) (*types.Transaction, error) {
+	return _EtherAlleyStore.Contract.PurchaseBatch(&_EtherAlleyStore.TransactOpts, to, ids, amounts, data)
+}
+
+// SafeBatchTransferFrom is a paid mutator transaction binding the contract method 0x2eb2c2d6.
+//
+// Solidity: function safeBatchTransferFrom(address from, address to, uint256[] ids, uint256[] amounts, bytes data) returns()
+func (_EtherAlleyStore *EtherAlleyStoreTransactor) SafeBatchTransferFrom(opts *bind.TransactOpts, from common.Address, to common.Address, ids []*big.Int, amounts []*big.Int, data []byte) (*types.Transaction, error) {
+	return _EtherAlleyStore.contract.Transact(opts, "safeBatchTransferFrom", from, to, ids, amounts, data)
+}
+
+// SafeBatchTransferFrom is a paid mutator transaction binding the contract method 0x2eb2c2d6.
+//
+// Solidity: function safeBatchTransferFrom(address from, address to, uint256[] ids, uint256[] amounts, bytes data) returns()
+func (_EtherAlleyStore *EtherAlleyStoreSession) SafeBatchTransferFrom(from common.Address, to common.Address, ids []*big.Int, amounts []*big.Int, data []byte) (*types.Transaction, error) {
+	return _EtherAlleyStore.Contract.SafeBatchTransferFrom(&_EtherAlleyStore.TransactOpts, from, to, ids, amounts, data)
+}
+
+// SafeBatchTransferFrom is a paid mutator transaction binding the contract method 0x2eb2c2d6.
+//
+// Solidity: function safeBatchTransferFrom(address from, address to, uint256[] ids, uint256[] amounts, bytes data) returns()
+func (_EtherAlleyStore *EtherAlleyStoreTransactorSession) SafeBatchTransferFrom(from common.Address, to common.Address, ids []*big.Int, amounts []*big.Int, data []byte) (*types.Transaction, error) {
+	return _EtherAlleyStore.Contract.SafeBatchTransferFrom(&_EtherAlleyStore.TransactOpts, from, to, ids, amounts, data)
+}
+
+// SafeTransferFrom is a paid mutator transaction binding the contract method 0xf242432a.
+//
+// Solidity: function safeTransferFrom(address from, address to, uint256 id, uint256 amount, bytes data) returns()
+func (_EtherAlleyStore *EtherAlleyStoreTransactor) SafeTransferFrom(opts *bind.TransactOpts, from common.Address, to common.Address, id *big.Int, amount *big.Int, data []byte) (*types.Transaction, error) {
+	return _EtherAlleyStore.contract.Transact(opts, "safeTransferFrom", from, to, id, amount, data)
+}
+
+// SafeTransferFrom is a paid mutator transaction binding the contract method 0xf242432a.
+//
+// Solidity: function safeTransferFrom(address from, address to, uint256 id, uint256 amount, bytes data) returns()
+func (_EtherAlleyStore *EtherAlleyStoreSession) SafeTransferFrom(from common.Address, to common.Address, id *big.Int, amount *big.Int, data []byte) (*types.Transaction, error) {
+	return _EtherAlleyStore.Contract.SafeTransferFrom(&_EtherAlleyStore.TransactOpts, from, to, id, amount, data)
+}
+
+// SafeTransferFrom is a paid mutator transaction binding the contract method 0xf242432a.
+//
+// Solidity: function safeTransferFrom(address from, address to, uint256 id, uint256 amount, bytes data) returns()
+func (_EtherAlleyStore *EtherAlleyStoreTransactorSession) SafeTransferFrom(from common.Address, to common.Address, id *big.Int, amount *big.Int, data []byte) (*types.Transaction, error) {
+	return _EtherAlleyStore.Contract.SafeTransferFrom(&_EtherAlleyStore.TransactOpts, from, to, id, amount, data)
+}
+
+// SetApprovalForAll is a paid mutator transaction binding the contract method 0xa22cb465.
+//
+// Solidity: function setApprovalForAll(address operator, bool approved) returns()
+func (_EtherAlleyStore *EtherAlleyStoreTransactor) SetApprovalForAll(opts *bind.TransactOpts, operator common.Address, approved bool) (*types.Transaction, error) {
+	return _EtherAlleyStore.contract.Transact(opts, "setApprovalForAll", operator, approved)
+}
+
+// SetApprovalForAll is a paid mutator transaction binding the contract method 0xa22cb465.
+//
+// Solidity: function setApprovalForAll(address operator, bool approved) returns()
+func (_EtherAlleyStore *EtherAlleyStoreSession) SetApprovalForAll(operator common.Address, approved bool) (*types.Transaction, error) {
+	return _EtherAlleyStore.Contract.SetApprovalForAll(&_EtherAlleyStore.TransactOpts, operator, approved)
+}
+
+// SetApprovalForAll is a paid mutator transaction binding the contract method 0xa22cb465.
+//
+// Solidity: function setApprovalForAll(address operator, bool approved) returns()
+func (_EtherAlleyStore *EtherAlleyStoreTransactorSession) SetApprovalForAll(operator common.Address, approved bool) (*types.Transaction, error) {
+	return _EtherAlleyStore.Contract.SetApprovalForAll(&_EtherAlleyStore.TransactOpts, operator, approved)
+}
+
+// SetListing is a paid mutator transaction binding the contract method 0x2fe8a4c3.
+//
+// Solidity: function setListing(uint256 id, bool purchasable, bool transferable, uint256 price, uint256 supplyLimit, uint256 balanceLimit) returns()
+func (_EtherAlleyStore *EtherAlleyStoreTransactor) SetListing(opts *bind.TransactOpts, id *big.Int, purchasable bool, transferable bool, price *big.Int, supplyLimit *big.Int, balanceLimit *big.Int) (*types.Transaction, error) {
+	return _EtherAlleyStore.contract.Transact(opts, "setListing", id, purchasable, transferable, price, supplyLimit, balanceLimit)
+}
+
+// SetListing is a paid mutator transaction binding the contract method 0x2fe8a4c3.
+//
+// Solidity: function setListing(uint256 id, bool purchasable, bool transferable, uint256 price, uint256 supplyLimit, uint256 balanceLimit) returns()
+func (_EtherAlleyStore *EtherAlleyStoreSession) SetListing(id *big.Int, purchasable bool, transferable bool, price *big.Int, supplyLimit *big.Int, balanceLimit *big.Int) (*types.Transaction, error) {
+	return _EtherAlleyStore.Contract.SetListing(&_EtherAlleyStore.TransactOpts, id, purchasable, transferable, price, supplyLimit, balanceLimit)
+}
+
+// SetListing is a paid mutator transaction binding the contract method 0x2fe8a4c3.
+//
+// Solidity: function setListing(uint256 id, bool purchasable, bool transferable, uint256 price, uint256 supplyLimit, uint256 balanceLimit) returns()
+func (_EtherAlleyStore *EtherAlleyStoreTransactorSession) SetListing(id *big.Int, purchasable bool, transferable bool, price *big.Int, supplyLimit *big.Int, balanceLimit *big.Int) (*types.Transaction, error) {
+	return _EtherAlleyStore.Contract.SetListing(&_EtherAlleyStore.TransactOpts, id, purchasable, transferable, price, supplyLimit, balanceLimit)
+}
+
+// SetURI is a paid mutator transaction binding the contract method 0x02fe5305.
+//
+// Solidity: function setURI(string newuri) returns()
+func (_EtherAlleyStore *EtherAlleyStoreTransactor) SetURI(opts *bind.TransactOpts, newuri string) (*types.Transaction, error) {
+	return _EtherAlleyStore.contract.Transact(opts, "setURI", newuri)
+}
+
+// SetURI is a paid mutator transaction binding the contract method 0x02fe5305.
+//
+// Solidity: function setURI(string newuri) returns()
+func (_EtherAlleyStore *EtherAlleyStoreSession) SetURI(newuri string) (*types.Transaction, error) {
+	return _EtherAlleyStore.Contract.SetURI(&_EtherAlleyStore.TransactOpts, newuri)
+}
+
+// SetURI is a paid mutator transaction binding the contract method 0x02fe5305.
+//
+// Solidity: function setURI(string newuri) returns()
+func (_EtherAlleyStore *EtherAlleyStoreTransactorSession) SetURI(newuri string) (*types.Transaction, error) {
+	return _EtherAlleyStore.Contract.SetURI(&_EtherAlleyStore.TransactOpts, newuri)
+}
+
+// TransferBalance is a paid mutator transaction binding the contract method 0x56a6d9ef.
+//
+// Solidity: function transferBalance(address to, uint256 amount) returns()
+func (_EtherAlleyStore *EtherAlleyStoreTransactor) TransferBalance(opts *bind.TransactOpts, to common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _EtherAlleyStore.contract.Transact(opts, "transferBalance", to, amount)
+}
+
+// TransferBalance is a paid mutator transaction binding the contract method 0x56a6d9ef.
+//
+// Solidity: function transferBalance(address to, uint256 amount) returns()
+func (_EtherAlleyStore *EtherAlleyStoreSession) TransferBalance(to common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _EtherAlleyStore.Contract.TransferBalance(&_EtherAlleyStore.TransactOpts, to, amount)
+}
+
+// TransferBalance is a paid mutator transaction binding the contract method 0x56a6d9ef.
+//
+// Solidity: function transferBalance(address to, uint256 amount) returns()
+func (_EtherAlleyStore *EtherAlleyStoreTransactorSession) TransferBalance(to common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _EtherAlleyStore.Contract.TransferBalance(&_EtherAlleyStore.TransactOpts, to, amount)
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_EtherAlleyStore *EtherAlleyStoreTransactor) Unpause(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _EtherAlleyStore.contract.Transact(opts, "unpause")
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_EtherAlleyStore *EtherAlleyStoreSession) Unpause() (*types.Transaction, error) {
+	return _EtherAlleyStore.Contract.Unpause(&_EtherAlleyStore.TransactOpts)
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_EtherAlleyStore *EtherAlleyStoreTransactorSession) Unpause() (*types.Transaction, error) {
+	return _EtherAlleyStore.Contract.Unpause(&_EtherAlleyStore.TransactOpts)
+}
+
+// EtherAlleyStoreApprovalForAllIterator is returned from FilterApprovalForAll and is used to iterate over the raw logs and unpacked data for ApprovalForAll events raised by the EtherAlleyStore contract.
+type EtherAlleyStoreApprovalForAllIterator struct {
+	Event *EtherAlleyStoreApprovalForAll // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *EtherAlleyStoreApprovalForAllIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(EtherAlleyStoreApprovalForAll)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(EtherAlleyStoreApprovalForAll)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *EtherAlleyStoreApprovalForAllIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *EtherAlleyStoreApprovalForAllIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// EtherAlleyStoreApprovalForAll represents a ApprovalForAll event raised by the EtherAlleyStore contract.
+type EtherAlleyStoreApprovalForAll struct {
+	Account  common.Address
+	Operator common.Address
+	Approved bool
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterApprovalForAll is a free log retrieval operation binding the contract event 0x17307eab39ab6107e8899845ad3d59bd9653f200f220920489ca2b5937696c31.
+//
+// Solidity: event ApprovalForAll(address indexed account, address indexed operator, bool approved)
+func (_EtherAlleyStore *EtherAlleyStoreFilterer) FilterApprovalForAll(opts *bind.FilterOpts, account []common.Address, operator []common.Address) (*EtherAlleyStoreApprovalForAllIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _EtherAlleyStore.contract.FilterLogs(opts, "ApprovalForAll", accountRule, operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &EtherAlleyStoreApprovalForAllIterator{contract: _EtherAlleyStore.contract, event: "ApprovalForAll", logs: logs, sub: sub}, nil
+}
+
+// WatchApprovalForAll is a free log subscription operation binding the contract event 0x17307eab39ab6107e8899845ad3d59bd9653f200f220920489ca2b5937696c31.
+//
+// Solidity: event ApprovalForAll(address indexed account, address indexed operator, bool approved)
+func (_EtherAlleyStore *EtherAlleyStoreFilterer) WatchApprovalForAll(opts *bind.WatchOpts, sink chan<- *EtherAlleyStoreApprovalForAll, account []common.Address, operator []common.Address) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _EtherAlleyStore.contract.WatchLogs(opts, "ApprovalForAll", accountRule, operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(EtherAlleyStoreApprovalForAll)
+				if err := _EtherAlleyStore.contract.UnpackLog(event, "ApprovalForAll", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseApprovalForAll is a log parse operation binding the contract event 0x17307eab39ab6107e8899845ad3d59bd9653f200f220920489ca2b5937696c31.
+//
+// Solidity: event ApprovalForAll(address indexed account, address indexed operator, bool approved)
+func (_EtherAlleyStore *EtherAlleyStoreFilterer) ParseApprovalForAll(log types.Log) (*EtherAlleyStoreApprovalForAll, error) {
+	event := new(EtherAlleyStoreApprovalForAll)
+	if err := _EtherAlleyStore.contract.UnpackLog(event, "ApprovalForAll", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// EtherAlleyStoreListingChangeIterator is returned from FilterListingChange and is used to iterate over the raw logs and unpacked data for ListingChange events raised by the EtherAlleyStore contract.
+type EtherAlleyStoreListingChangeIterator struct {
+	Event *EtherAlleyStoreListingChange // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *EtherAlleyStoreListingChangeIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(EtherAlleyStoreListingChange)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(EtherAlleyStoreListingChange)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *EtherAlleyStoreListingChangeIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *EtherAlleyStoreListingChangeIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// EtherAlleyStoreListingChange represents a ListingChange event raised by the EtherAlleyStore contract.
+type EtherAlleyStoreListingChange struct {
+	Id           *big.Int
+	Purchasable  bool
+	Transferable bool
+	Price        *big.Int
+	SupplyLimit  *big.Int
+	BalanceLimit *big.Int
+	Supply       *big.Int
+	Raw          types.Log // Blockchain specific contextual infos
+}
+
+// FilterListingChange is a free log retrieval operation binding the contract event 0xd62d82d72db3289f1f82f55480c2e382f45f54eb61a9b93034c426343bd8a55f.
+//
+// Solidity: event ListingChange(uint256 id, bool purchasable, bool transferable, uint256 price, uint256 supplyLimit, uint256 balanceLimit, uint256 supply)
+func (_EtherAlleyStore *EtherAlleyStoreFilterer) FilterListingChange(opts *bind.FilterOpts) (*EtherAlleyStoreListingChangeIterator, error) {
+
+	logs, sub, err := _EtherAlleyStore.contract.FilterLogs(opts, "ListingChange")
+	if err != nil {
+		return nil, err
+	}
+	return &EtherAlleyStoreListingChangeIterator{contract: _EtherAlleyStore.contract, event: "ListingChange", logs: logs, sub: sub}, nil
+}
+
+// WatchListingChange is a free log subscription operation binding the contract event 0xd62d82d72db3289f1f82f55480c2e382f45f54eb61a9b93034c426343bd8a55f.
+//
+// Solidity: event ListingChange(uint256 id, bool purchasable, bool transferable, uint256 price, uint256 supplyLimit, uint256 balanceLimit, uint256 supply)
+func (_EtherAlleyStore *EtherAlleyStoreFilterer) WatchListingChange(opts *bind.WatchOpts, sink chan<- *EtherAlleyStoreListingChange) (event.Subscription, error) {
+
+	logs, sub, err := _EtherAlleyStore.contract.WatchLogs(opts, "ListingChange")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(EtherAlleyStoreListingChange)
+				if err := _EtherAlleyStore.contract.UnpackLog(event, "ListingChange", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseListingChange is a log parse operation binding the contract event 0xd62d82d72db3289f1f82f55480c2e382f45f54eb61a9b93034c426343bd8a55f.
+//
+// Solidity: event ListingChange(uint256 id, bool purchasable, bool transferable, uint256 price, uint256 supplyLimit, uint256 balanceLimit, uint256 supply)
+func (_EtherAlleyStore *EtherAlleyStoreFilterer) ParseListingChange(log types.Log) (*EtherAlleyStoreListingChange, error) {
+	event := new(EtherAlleyStoreListingChange)
+	if err := _EtherAlleyStore.contract.UnpackLog(event, "ListingChange", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// EtherAlleyStoreTransferBatchIterator is returned from FilterTransferBatch and is used to iterate over the raw logs and unpacked data for TransferBatch events raised by the EtherAlleyStore contract.
+type EtherAlleyStoreTransferBatchIterator struct {
+	Event *EtherAlleyStoreTransferBatch // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *EtherAlleyStoreTransferBatchIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(EtherAlleyStoreTransferBatch)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(EtherAlleyStoreTransferBatch)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *EtherAlleyStoreTransferBatchIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *EtherAlleyStoreTransferBatchIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// EtherAlleyStoreTransferBatch represents a TransferBatch event raised by the EtherAlleyStore contract.
+type EtherAlleyStoreTransferBatch struct {
+	Operator common.Address
+	From     common.Address
+	To       common.Address
+	Ids      []*big.Int
+	Values   []*big.Int
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterTransferBatch is a free log retrieval operation binding the contract event 0x4a39dc06d4c0dbc64b70af90fd698a233a518aa5d07e595d983b8c0526c8f7fb.
+//
+// Solidity: event TransferBatch(address indexed operator, address indexed from, address indexed to, uint256[] ids, uint256[] values)
+func (_EtherAlleyStore *EtherAlleyStoreFilterer) FilterTransferBatch(opts *bind.FilterOpts, operator []common.Address, from []common.Address, to []common.Address) (*EtherAlleyStoreTransferBatchIterator, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _EtherAlleyStore.contract.FilterLogs(opts, "TransferBatch", operatorRule, fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return &EtherAlleyStoreTransferBatchIterator{contract: _EtherAlleyStore.contract, event: "TransferBatch", logs: logs, sub: sub}, nil
+}
+
+// WatchTransferBatch is a free log subscription operation binding the contract event 0x4a39dc06d4c0dbc64b70af90fd698a233a518aa5d07e595d983b8c0526c8f7fb.
+//
+// Solidity: event TransferBatch(address indexed operator, address indexed from, address indexed to, uint256[] ids, uint256[] values)
+func (_EtherAlleyStore *EtherAlleyStoreFilterer) WatchTransferBatch(opts *bind.WatchOpts, sink chan<- *EtherAlleyStoreTransferBatch, operator []common.Address, from []common.Address, to []common.Address) (event.Subscription, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _EtherAlleyStore.contract.WatchLogs(opts, "TransferBatch", operatorRule, fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(EtherAlleyStoreTransferBatch)
+				if err := _EtherAlleyStore.contract.UnpackLog(event, "TransferBatch", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseTransferBatch is a log parse operation binding the contract event 0x4a39dc06d4c0dbc64b70af90fd698a233a518aa5d07e595d983b8c0526c8f7fb.
+//
+// Solidity: event TransferBatch(address indexed operator, address indexed from, address indexed to, uint256[] ids, uint256[] values)
+func (_EtherAlleyStore *EtherAlleyStoreFilterer) ParseTransferBatch(log types.Log) (*EtherAlleyStoreTransferBatch, error) {
+	event := new(EtherAlleyStoreTransferBatch)
+	if err := _EtherAlleyStore.contract.UnpackLog(event, "TransferBatch", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// EtherAlleyStoreTransferSingleIterator is returned from FilterTransferSingle and is used to iterate over the raw logs and unpacked data for TransferSingle events raised by the EtherAlleyStore contract.
+type EtherAlleyStoreTransferSingleIterator struct {
+	Event *EtherAlleyStoreTransferSingle // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *EtherAlleyStoreTransferSingleIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(EtherAlleyStoreTransferSingle)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(EtherAlleyStoreTransferSingle)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *EtherAlleyStoreTransferSingleIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *EtherAlleyStoreTransferSingleIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// EtherAlleyStoreTransferSingle represents a TransferSingle event raised by the EtherAlleyStore contract.
+type EtherAlleyStoreTransferSingle struct {
+	Operator common.Address
+	From     common.Address
+	To       common.Address
+	Id       *big.Int
+	Value    *big.Int
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterTransferSingle is a free log retrieval operation binding the contract event 0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62.
+//
+// Solidity: event TransferSingle(address indexed operator, address indexed from, address indexed to, uint256 id, uint256 value)
+func (_EtherAlleyStore *EtherAlleyStoreFilterer) FilterTransferSingle(opts *bind.FilterOpts, operator []common.Address, from []common.Address, to []common.Address) (*EtherAlleyStoreTransferSingleIterator, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _EtherAlleyStore.contract.FilterLogs(opts, "TransferSingle", operatorRule, fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return &EtherAlleyStoreTransferSingleIterator{contract: _EtherAlleyStore.contract, event: "TransferSingle", logs: logs, sub: sub}, nil
+}
+
+// WatchTransferSingle is a free log subscription operation binding the contract event 0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62.
+//
+// Solidity: event TransferSingle(address indexed operator, address indexed from, address indexed to, uint256 id, uint256 value)
+func (_EtherAlleyStore *EtherAlleyStoreFilterer) WatchTransferSingle(opts *bind.WatchOpts, sink chan<- *EtherAlleyStoreTransferSingle, operator []common.Address, from []common.Address, to []common.Address) (event.Subscription, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _EtherAlleyStore.contract.WatchLogs(opts, "TransferSingle", operatorRule, fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(EtherAlleyStoreTransferSingle)
+				if err := _EtherAlleyStore.contract.UnpackLog(event, "TransferSingle", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseTransferSingle is a log parse operation binding the contract event 0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62.
+//
+// Solidity: event TransferSingle(address indexed operator, address indexed from, address indexed to, uint256 id, uint256 value)
+func (_EtherAlleyStore *EtherAlleyStoreFilterer) ParseTransferSingle(log types.Log) (*EtherAlleyStoreTransferSingle, error) {
+	event := new(EtherAlleyStoreTransferSingle)
+	if err := _EtherAlleyStore.contract.UnpackLog(event, "TransferSingle", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// EtherAlleyStoreURIIterator is returned from FilterURI and is used to iterate over the raw logs and unpacked data for URI events raised by the EtherAlleyStore contract.
+type EtherAlleyStoreURIIterator struct {
+	Event *EtherAlleyStoreURI // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *EtherAlleyStoreURIIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(EtherAlleyStoreURI)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(EtherAlleyStoreURI)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *EtherAlleyStoreURIIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *EtherAlleyStoreURIIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// EtherAlleyStoreURI represents a URI event raised by the EtherAlleyStore contract.
+type EtherAlleyStoreURI struct {
+	Value string
+	Id    *big.Int
+	Raw   types.Log // Blockchain specific contextual infos
+}
+
+// FilterURI is a free log retrieval operation binding the contract event 0x6bb7ff708619ba0610cba295a58592e0451dee2622938c8755667688daf3529b.
+//
+// Solidity: event URI(string value, uint256 indexed id)
+func (_EtherAlleyStore *EtherAlleyStoreFilterer) FilterURI(opts *bind.FilterOpts, id []*big.Int) (*EtherAlleyStoreURIIterator, error) {
+
+	var idRule []interface{}
+	for _, idItem := range id {
+		idRule = append(idRule, idItem)
+	}
+
+	logs, sub, err := _EtherAlleyStore.contract.FilterLogs(opts, "URI", idRule)
+	if err != nil {
+		return nil, err
+	}
+	return &EtherAlleyStoreURIIterator{contract: _EtherAlleyStore.contract, event: "URI", logs: logs, sub: sub}, nil
+}
+
+// WatchURI is a free log subscription operation binding the contract event 0x6bb7ff708619ba0610cba295a58592e0451dee2622938c8755667688daf3529b.
+//
+// Solidity: event URI(string value, uint256 indexed id)
+func (_EtherAlleyStore *EtherAlleyStoreFilterer) WatchURI(opts *bind.WatchOpts, sink chan<- *EtherAlleyStoreURI, id []*big.Int) (event.Subscription, error) {
+
+	var idRule []interface{}
+	for _, idItem := range id {
+		idRule = append(idRule, idItem)
+	}
+
+	logs, sub, err := _EtherAlleyStore.contract.WatchLogs(opts, "URI", idRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(EtherAlleyStoreURI)
+				if err := _EtherAlleyStore.contract.UnpackLog(event, "URI", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseURI is a log parse operation binding the contract event 0x6bb7ff708619ba0610cba295a58592e0451dee2622938c8755667688daf3529b.
+//
+// Solidity: event URI(string value, uint256 indexed id)
+func (_EtherAlleyStore *EtherAlleyStoreFilterer) ParseURI(log types.Log) (*EtherAlleyStoreURI, error) {
+	event := new(EtherAlleyStoreURI)
+	if err := _EtherAlleyStore.contract.UnpackLog(event, "URI", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/gateways/ethereum/nft.go
+++ b/gateways/ethereum/nft.go
@@ -128,6 +128,7 @@ func (gw *gateway) getErc1155URI(client *ethclient.Client, address common.Addres
 		return "", err
 	}
 
+	// See https://eips.ethereum.org/EIPS/eip-1155: token ids are passed in hexidecimal form
 	hexId := hex.EncodeToString(id.Bytes())
 	uri = strings.Replace(uri, "{id}", hexId, 1)
 

--- a/gateways/ethereum/store.go
+++ b/gateways/ethereum/store.go
@@ -59,7 +59,7 @@ func (gw *gateway) GetStoreListingInfo(ctx context.Context, ids *[]string) (*[]e
 	return &listings, err
 }
 
-func (gw *gateway) GetStoreBalanceBatch(ctx context.Context, address string, ids *[]string) (*[]string, error) {
+func (gw *gateway) GetStoreBalanceBatch(ctx context.Context, address string, ids *[]string) ([]*big.Int, error) {
 	client, err := gw.getClient(ctx, gw.settings.StoreBlockchain())
 
 	if err != nil {
@@ -91,16 +91,16 @@ func (gw *gateway) GetStoreBalanceBatch(ctx context.Context, address string, ids
 		accountsArr[i] = common.HexToAddress(address)
 	}
 
-	balancesArr, err := instance.BalanceOfBatch(&bind.CallOpts{}, accountsArr, idsArr)
+	return instance.BalanceOfBatch(&bind.CallOpts{}, accountsArr, idsArr)
 
-	if err != nil {
-		return nil, err
-	}
+	// if err != nil {
+	// 	return nil, err
+	// }
 
-	balences := make([]string, len(*ids))
-	for i := 0; i < len(*ids); i++ {
-		balences[i] = balancesArr[i].String()
-	}
+	// balences := make([]string, len(*ids))
+	// for i := 0; i < len(*ids); i++ {
+	// 	balences[i] = balancesArr[i].String()
+	// }
 
-	return &balences, err
+	// return &balences, err
 }

--- a/gateways/ethereum/store.go
+++ b/gateways/ethereum/store.go
@@ -1,0 +1,106 @@
+package ethereum
+
+import (
+	"context"
+	"errors"
+	"math/big"
+
+	"github.com/etheralley/etheralley-core-api/entities"
+	"github.com/etheralley/etheralley-core-api/gateways/ethereum/contracts"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func (gw *gateway) GetStoreListingInfo(ctx context.Context, ids *[]string) (*[]entities.ListingInfo, error) {
+	client, err := gw.getClient(ctx, gw.settings.StoreBlockchain())
+
+	if err != nil {
+		return nil, err
+	}
+
+	contractAddress := common.HexToAddress(gw.settings.StoreAddress())
+
+	instance, err := contracts.NewEtherAlleyStore(contractAddress, client)
+
+	if err != nil {
+		return nil, err
+	}
+
+	idsArr := []*big.Int{}
+
+	for _, id := range *ids {
+		n := new(big.Int)
+		n, ok := n.SetString(id, 10)
+
+		if !ok {
+			return nil, errors.New("err parsing id into big int")
+		}
+
+		idsArr = append(idsArr, n)
+	}
+
+	listingsArr, err := instance.GetListingBatch(&bind.CallOpts{}, idsArr)
+
+	if err != nil {
+		return nil, err
+	}
+
+	listings := []entities.ListingInfo{}
+	for _, listing := range listingsArr {
+		listings = append(listings, entities.ListingInfo{
+			Purchasable:  listing.Purchasable,
+			Transferable: listing.Transferable,
+			Price:        listing.Price.String(),
+			SupplyLimit:  listing.SupplyLimit.String(),
+			BalanceLimit: listing.BalanceLimit.String(),
+		})
+	}
+
+	return &listings, err
+}
+
+func (gw *gateway) GetStoreBalanceBatch(ctx context.Context, address string, ids *[]string) (*[]string, error) {
+	client, err := gw.getClient(ctx, gw.settings.StoreBlockchain())
+
+	if err != nil {
+		return nil, err
+	}
+
+	contractAddress := common.HexToAddress(gw.settings.StoreAddress())
+
+	instance, err := contracts.NewEtherAlleyStore(contractAddress, client)
+
+	if err != nil {
+		return nil, err
+	}
+
+	idsArr := []*big.Int{}
+	for _, id := range *ids {
+		n := new(big.Int)
+		n, ok := n.SetString(id, 10)
+
+		if !ok {
+			return nil, errors.New("err parsing id into big int")
+		}
+
+		idsArr = append(idsArr, n)
+	}
+
+	accountsArr := make([]common.Address, len(*ids))
+	for i := 0; i < len(*ids); i++ {
+		accountsArr[i] = common.HexToAddress(address)
+	}
+
+	balancesArr, err := instance.BalanceOfBatch(&bind.CallOpts{}, accountsArr, idsArr)
+
+	if err != nil {
+		return nil, err
+	}
+
+	balences := make([]string, len(*ids))
+	for i := 0; i < len(*ids); i++ {
+		balences[i] = balancesArr[i].String()
+	}
+
+	return &balences, err
+}

--- a/gateways/gateway.go
+++ b/gateways/gateway.go
@@ -49,6 +49,9 @@ type IBlockchainGateway interface {
 	GetENSNameFromAddress(ctx context.Context, address string) (name string, err error)
 
 	GetTransactionData(ctx context.Context, tx *entities.Transaction) (*entities.TransactionData, error)
+
+	GetStoreListingInfo(ctx context.Context, ids *[]string) (*[]entities.ListingInfo, error)
+	GetStoreBalanceBatch(ctx context.Context, address string, ids *[]string) (*[]string, error)
 }
 
 type IBlockchainIndexGateway interface {

--- a/gateways/gateway.go
+++ b/gateways/gateway.go
@@ -2,6 +2,7 @@ package gateways
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/etheralley/etheralley-core-api/entities"
 )
@@ -51,7 +52,7 @@ type IBlockchainGateway interface {
 	GetTransactionData(ctx context.Context, tx *entities.Transaction) (*entities.TransactionData, error)
 
 	GetStoreListingInfo(ctx context.Context, ids *[]string) (*[]entities.ListingInfo, error)
-	GetStoreBalanceBatch(ctx context.Context, address string, ids *[]string) (*[]string, error)
+	GetStoreBalanceBatch(ctx context.Context, address string, ids *[]string) ([]*big.Int, error)
 }
 
 type IBlockchainIndexGateway interface {

--- a/gateways/redis/gateway.go
+++ b/gateways/redis/gateway.go
@@ -34,6 +34,7 @@ type profileJson struct {
 	Address           string                  `json:"address"`
 	ENSName           string                  `json:"ens_name"`
 	DisplayConfig     *displayConfigJson      `json:"display_config,omitempty"`
+	StoreAssets       *storeAssetsJson        `json:"store_assets"`
 	NonFungibleTokens *[]nonFungibleTokenJson `json:"non_fungible_tokens"`
 	FungibleTokens    *[]fungibleTokenJson    `json:"fungible_tokens"`
 	Statistics        *[]statisticJson        `json:"statistics"`
@@ -87,6 +88,11 @@ type interactionJson struct {
 type transactionJson struct {
 	Id         string            `json:"id"`
 	Blockchain common.Blockchain `json:"blockchain"`
+}
+
+type storeAssetsJson struct {
+	Premium    bool `json:"premium"`
+	BetaTester bool `json:"beta_tester"`
 }
 
 type displayConfigJson struct {
@@ -262,8 +268,12 @@ func fromProfileJson(profileJson *profileJson) *entities.Profile {
 	}
 
 	return &entities.Profile{
-		Address:           profileJson.Address,
-		ENSName:           profileJson.ENSName,
+		Address: profileJson.Address,
+		ENSName: profileJson.ENSName,
+		StoreAssets: &entities.StoreAssets{
+			Premium:    profileJson.StoreAssets.Premium,
+			BetaTester: profileJson.StoreAssets.BetaTester,
+		},
 		DisplayConfig:     config,
 		NonFungibleTokens: &nfts,
 		FungibleTokens:    &tokens,
@@ -415,8 +425,12 @@ func toProfileJson(profile *entities.Profile) *profileJson {
 	}
 
 	return &profileJson{
-		Address:           profile.Address,
-		ENSName:           profile.ENSName,
+		Address: profile.Address,
+		ENSName: profile.ENSName,
+		StoreAssets: &storeAssetsJson{
+			Premium:    profile.StoreAssets.Premium,
+			BetaTester: profile.StoreAssets.BetaTester,
+		},
 		DisplayConfig:     config,
 		NonFungibleTokens: &nfts,
 		FungibleTokens:    &tokens,

--- a/main.go
+++ b/main.go
@@ -60,6 +60,7 @@ func main() {
 	container.Provide(usecases.NewGetTopProfilesUseCase)
 	container.Provide(usecases.NewGetListingMetadata)
 	container.Provide(usecases.NewGetListings)
+	container.Provide(usecases.NewRefreshProfileUseCase)
 	container.Provide(httpPresenters.NewPresenter)
 	container.Provide(httpControllers.NewHttpController)
 

--- a/main.go
+++ b/main.go
@@ -58,6 +58,8 @@ func main() {
 	container.Provide(usecases.NewGetAllInteractionsUseCase)
 	container.Provide(usecases.NewRecordProfileViewUseCase)
 	container.Provide(usecases.NewGetTopProfilesUseCase)
+	container.Provide(usecases.NewGetListingMetadata)
+	container.Provide(usecases.NewGetListings)
 	container.Provide(httpPresenters.NewPresenter)
 	container.Provide(httpControllers.NewHttpController)
 

--- a/presenters/http/http.go
+++ b/presenters/http/http.go
@@ -66,8 +66,12 @@ func toChallengeJson(challenge *entities.Challenge) *challengeJson {
 
 func toProfileJson(profile *entities.Profile) *profileJson {
 	return &profileJson{
-		Address:           profile.Address,
-		ENSName:           profile.ENSName,
+		Address: profile.Address,
+		ENSName: profile.ENSName,
+		StoreAssets: &storeAssetsJson{
+			Premium:    profile.StoreAssets.Premium,
+			BetaTester: profile.StoreAssets.BetaTester,
+		},
 		DisplayConfig:     toDisplayConfigJson(profile.DisplayConfig),
 		NonFungibleTokens: toNonFungibleTokensJson(profile.NonFungibleTokens),
 		FungibleTokens:    toFungibleTokensJson(profile.FungibleTokens),
@@ -276,6 +280,7 @@ type challengeJson struct {
 type profileJson struct {
 	Address           string                  `json:"address"`
 	ENSName           string                  `json:"ens_name"`
+	StoreAssets       *storeAssetsJson        `json:"store_assets"`
 	DisplayConfig     *displayConfigJson      `json:"display_config,omitempty"`
 	NonFungibleTokens *[]nonFungibleTokenJson `json:"non_fungible_tokens"`
 	FungibleTokens    *[]fungibleTokenJson    `json:"fungible_tokens"`
@@ -330,6 +335,11 @@ type interactionJson struct {
 type transactiontJson struct {
 	Id         string            `json:"id"`
 	Blockchain common.Blockchain `json:"blockchain"`
+}
+
+type storeAssetsJson struct {
+	Premium    bool `json:"premium"`
+	BetaTester bool `json:"beta_tester"`
 }
 
 type displayConfigJson struct {

--- a/presenters/http/listing.go
+++ b/presenters/http/listing.go
@@ -1,0 +1,19 @@
+package http
+
+import (
+	"net/http"
+
+	"github.com/etheralley/etheralley-core-api/entities"
+)
+
+func (p *httpPresenter) PresentListingMetadata(w http.ResponseWriter, r *http.Request, metadata *entities.NonFungibleMetadata) {
+	json := toNonFungibleMetadataJson(metadata)
+
+	p.presentJSON(w, r, http.StatusOK, json)
+}
+
+func (p *httpPresenter) PresentListings(w http.ResponseWriter, r *http.Request, listings *[]entities.Listing) {
+	json := toListingsJson(listings)
+
+	p.presentJSON(w, r, http.StatusOK, json)
+}

--- a/presenters/http/profile.go
+++ b/presenters/http/profile.go
@@ -25,3 +25,7 @@ func (p *httpPresenter) PresentTopProfiles(w http.ResponseWriter, r *http.Reques
 
 	p.presentJSON(w, r, http.StatusOK, json)
 }
+
+func (p *httpPresenter) PresentRefreshedProfile(w http.ResponseWriter, r *http.Request) {
+	p.presentStatus(w, r, http.StatusOK)
+}

--- a/presenters/presenter.go
+++ b/presenters/presenter.go
@@ -20,4 +20,5 @@ type IPresenter interface {
 	PresentTopProfiles(http.ResponseWriter, *http.Request, *[]entities.Profile)
 	PresentListingMetadata(http.ResponseWriter, *http.Request, *entities.NonFungibleMetadata)
 	PresentListings(http.ResponseWriter, *http.Request, *[]entities.Listing)
+	PresentRefreshedProfile(w http.ResponseWriter, r *http.Request)
 }

--- a/presenters/presenter.go
+++ b/presenters/presenter.go
@@ -18,4 +18,6 @@ type IPresenter interface {
 	PresentProfile(http.ResponseWriter, *http.Request, *entities.Profile)
 	PresentSavedProfile(http.ResponseWriter, *http.Request)
 	PresentTopProfiles(http.ResponseWriter, *http.Request, *[]entities.Profile)
+	PresentListingMetadata(http.ResponseWriter, *http.Request, *entities.NonFungibleMetadata)
+	PresentListings(http.ResponseWriter, *http.Request, *[]entities.Listing)
 }

--- a/usecases/get_listing_metadata.go
+++ b/usecases/get_listing_metadata.go
@@ -1,0 +1,54 @@
+package usecases
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/etheralley/etheralley-core-api/common"
+	"github.com/etheralley/etheralley-core-api/entities"
+)
+
+type GetListingMetadataInput struct {
+	TokenId string `validate:"required,numeric"`
+}
+
+type IGetListingMetadataUseCase func(ctx context.Context, input *GetListingMetadataInput) (metadata *entities.NonFungibleMetadata, err error)
+
+func NewGetListingMetadata(
+	logger common.ILogger,
+	settings common.ISettings,
+) IGetListingMetadataUseCase {
+	return func(ctx context.Context, input *GetListingMetadataInput) (*entities.NonFungibleMetadata, error) {
+		if err := common.ValidateStruct(input); err != nil {
+			return nil, err
+		}
+
+		switch input.TokenId {
+		case "01":
+			return &entities.NonFungibleMetadata{
+				Name:        "Ether Alley Premium Membership",
+				Description: "This token gives the holder access to premium features on EtherAlley.io",
+				Image:       getImageUrl(settings.StoreImageURI(), "01"),
+				Attributes: &[]map[string]interface{}{
+					{"atr1": "val1", "atr2": "val2"},
+				},
+			}, nil
+		case "02":
+			return &entities.NonFungibleMetadata{
+				Name:        "Ether Alley Beta Tester",
+				Description: "The holder of this token participated in the Ether Alley beta. This token is non transferable",
+				Image:       getImageUrl(settings.StoreImageURI(), "01"),
+				Attributes: &[]map[string]interface{}{
+					{"atr1": "val1", "atr2": "val2"},
+				},
+			}, nil
+		}
+
+		return nil, errors.New("unspported token id")
+	}
+}
+
+func getImageUrl(baseUrl string, tokenId string) string {
+	return fmt.Sprintf("%v/store/%v.png", baseUrl, tokenId)
+}

--- a/usecases/get_listing_metadata.go
+++ b/usecases/get_listing_metadata.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/etheralley/etheralley-core-api/common"
 	"github.com/etheralley/etheralley-core-api/entities"
@@ -24,8 +25,15 @@ func NewGetListingMetadata(
 			return nil, err
 		}
 
-		switch input.TokenId {
-		case "01":
+		// See https://eips.ethereum.org/EIPS/eip-1155: token ids are passed in hexidecimal form
+		tokenId, err := strconv.ParseInt(input.TokenId, 16, 64)
+
+		if err != nil {
+			return nil, err
+		}
+
+		switch fmt.Sprint(tokenId) {
+		case common.STORE_PREMIUM:
 			return &entities.NonFungibleMetadata{
 				Name:        "Ether Alley Premium Membership",
 				Description: "This token gives the holder access to premium features on EtherAlley.io",
@@ -34,7 +42,7 @@ func NewGetListingMetadata(
 					{"atr1": "val1", "atr2": "val2"},
 				},
 			}, nil
-		case "02":
+		case common.STORE_BETA_TESTER:
 			return &entities.NonFungibleMetadata{
 				Name:        "Ether Alley Beta Tester",
 				Description: "The holder of this token participated in the Ether Alley beta. This token is non transferable",

--- a/usecases/get_listings.go
+++ b/usecases/get_listings.go
@@ -1,0 +1,60 @@
+package usecases
+
+import (
+	"context"
+
+	"github.com/etheralley/etheralley-core-api/common"
+	"github.com/etheralley/etheralley-core-api/entities"
+	"github.com/etheralley/etheralley-core-api/gateways"
+)
+
+type GetListingsInput struct {
+	TokenIds *[]string `json:"token_ids" validate:"required,dive,numeric"`
+}
+
+type IGetListingsUseCase func(ctx context.Context, input *GetListingsInput) (listings *[]entities.Listing, err error)
+
+func NewGetListings(
+	logger common.ILogger,
+	settings common.ISettings,
+	blockchainGateway gateways.IBlockchainGateway,
+	getListingMetadata IGetListingMetadataUseCase,
+) IGetListingsUseCase {
+	return func(ctx context.Context, input *GetListingsInput) (*[]entities.Listing, error) {
+		if err := common.ValidateStruct(input); err != nil {
+			return nil, err
+		}
+
+		ids := *input.TokenIds
+
+		listingInfo, err := blockchainGateway.GetStoreListingInfo(ctx, &ids)
+
+		if err != nil {
+			return nil, err
+		}
+
+		listings := make([]entities.Listing, len(ids))
+		for i := 0; i < len(ids); i++ {
+			metadata, err := getListingMetadata(ctx, &GetListingMetadataInput{
+				TokenId: ids[i],
+			})
+
+			if err != nil {
+				return nil, err
+			}
+
+			listings[i] = entities.Listing{
+				Contract: &entities.Contract{
+					Blockchain: settings.StoreBlockchain(),
+					Address:    settings.StoreAddress(),
+					Interface:  common.ERC1155,
+				},
+				TokenId:  ids[i],
+				Info:     &(*listingInfo)[i],
+				Metadata: metadata,
+			}
+		}
+
+		return &listings, err
+	}
+}

--- a/usecases/refresh_profile.go
+++ b/usecases/refresh_profile.go
@@ -1,0 +1,45 @@
+package usecases
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/etheralley/etheralley-core-api/common"
+	"github.com/etheralley/etheralley-core-api/gateways"
+)
+
+type RefreshProfileInput struct {
+	Address string `validate:"required,eth_addr"`
+}
+
+// Refresh any relevant transient info that is currently cached
+//
+// Info that is currently refreshed:
+//
+// - Store Assets
+type IRefreshProfileUseCase func(ctx context.Context, input *RefreshProfileInput) error
+
+func NewRefreshProfileUseCase(logger common.ILogger, cacheGateway gateways.ICacheGateway, blockchainGateway gateways.IBlockchainGateway) IRefreshProfileUseCase {
+	return func(ctx context.Context, input *RefreshProfileInput) error {
+		if err := common.ValidateStruct(input); err != nil {
+			return err
+		}
+
+		profile, err := cacheGateway.GetProfileByAddress(ctx, input.Address)
+
+		if err != nil {
+			return err
+		}
+
+		balances, err := blockchainGateway.GetStoreBalanceBatch(ctx, input.Address, &[]string{common.STORE_PREMIUM, common.STORE_BETA_TESTER})
+
+		if err != nil {
+			return err
+		}
+
+		profile.StoreAssets.Premium = balances[0].Cmp(big.NewInt(0)) == 1
+		profile.StoreAssets.BetaTester = balances[1].Cmp(big.NewInt(0)) == 1
+
+		return cacheGateway.SaveProfile(ctx, profile)
+	}
+}

--- a/usecases/resolve_address.go
+++ b/usecases/resolve_address.go
@@ -12,7 +12,7 @@ type ResolveAddressInput struct {
 	Value string `validate:"required"`
 }
 
-// resolve an address from an ens name
+// Resolve an address from an ens name
 type IResolveAddressUseCase func(ctx context.Context, input *ResolveAddressInput) (address string, err error)
 
 // Attempts to detect provided input format and resolve ens address

--- a/usecases/resolve_name.go
+++ b/usecases/resolve_name.go
@@ -12,7 +12,7 @@ type ResolveENSNameInput struct {
 	Address string `validate:"required,eth_addr"`
 }
 
-// resolve an ens name for an address
+// Resolve an ens name for an address
 type IResolveENSNameUseCase func(ctx context.Context, input *ResolveENSNameInput) (name string, err error)
 
 // Provided address is normalized to avoid user error


### PR DESCRIPTION
Changes:
- Adding store asset ownership to profile as part of transient info fetching
- Route to get listings by array of ids
  - this will be consumed by the web UI to display a list of purchasable store assets
- Route to get listing metadata
  - The uri function of the ERC1155 store contract will point to this endpoint to resolve metadata for a given store token id
- Route to refresh the store assets values that are cached
  - This endpoint will have to be called by the UI at some point after the transaction is processed by the store so that the user visually sees there new purchases immediately
-  Including some refactoring in the default profile logic
- Other small cleanup