### PR TITLE
handling rate limiting with function retry

### DIFF
--- a/common/retry.go
+++ b/common/retry.go
@@ -1,0 +1,70 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"reflect"
+	"time"
+)
+
+var MAX_RETRIES float64 = 4
+
+// TODO:
+// - Only retry on specific errors
+//
+// Invoke a function with exponential backoff retries when an error is encountered.
+// FunctionRetrier acceps a function fn with any signature and an arbitrary number of args.
+// FunctionRetrier will invoke fn with args and return the cast result T and an error
+// This was originally implemented to solve us getting rate limited by the alchemy APIs
+// See: https://docs.alchemy.com/alchemy/documentation/rate-limits#retries
+func FunctionRetrier[T any](ctx context.Context, logger ILogger, fn any, args ...any) (result T, err error) {
+	var tries float64 = 0
+	for {
+		select {
+		case <-ctx.Done():
+			return result, fmt.Errorf("exceeded context deadline: %w", err)
+		default:
+			if tries >= MAX_RETRIES {
+				return result, fmt.Errorf("exceeded max retries: %w", err)
+			}
+
+			result, err = invoker[T](fn, args...)
+
+			if err == nil {
+				return result, nil
+			}
+
+			// sleep a power of two seconds + a random number of seconds between 0 and 1
+			sleepSecs := (time.Second * time.Duration(math.Pow(2, tries))) + time.Duration((rand.Float64() * float64(time.Second)))
+
+			logger.Debugf(ctx, "retrier failed on try %v with err %v sleeping %v", tries, sleepSecs, err)
+
+			tries++
+
+			time.Sleep(sleepSecs)
+		}
+	}
+}
+
+func invoker[T any](fn any, args ...any) (result T, err error) {
+	fnValue := reflect.ValueOf(fn)
+	arguments := []reflect.Value{}
+	for _, arg := range args {
+		arguments = append(arguments, reflect.ValueOf(arg))
+	}
+
+	fnResults := fnValue.Call(arguments)
+
+	fnResult := fnResults[0].Interface()
+	fnErr := fnResults[1].Interface()
+
+	if fnErr != nil {
+		err = fnErr.(error)
+		return result, err
+	}
+
+	result = fnResult.(T)
+	return result, err
+}

--- a/controllers/http/timeout.go
+++ b/controllers/http/timeout.go
@@ -14,7 +14,7 @@ import (
 // see https://github.com/go-chi/chi/blob/master/middleware/timeout.go#L33
 func (hc *HttpController) timeout(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx, cancel := context.WithTimeout(r.Context(), time.Second*5)
+		ctx, cancel := context.WithTimeout(r.Context(), time.Second*30)
 
 		defer cancel()
 

--- a/gateways/ethereum/ens.go
+++ b/gateways/ethereum/ens.go
@@ -15,7 +15,7 @@ func (gw *gateway) GetENSAddressFromName(ctx context.Context, name string) (addr
 		return
 	}
 
-	adr, err := ens.Resolve(client, name)
+	adr, err := cmn.FunctionRetrier[common.Address](ctx, gw.logger, ens.Resolve, client, name)
 
 	if err != nil {
 		return
@@ -33,5 +33,5 @@ func (gw *gateway) GetENSNameFromAddress(ctx context.Context, address string) (n
 		return
 	}
 
-	return ens.ReverseResolve(client, common.HexToAddress(address))
+	return cmn.FunctionRetrier[string](ctx, gw.logger, ens.ReverseResolve, client, common.HexToAddress(address))
 }

--- a/gateways/ethereum/token.go
+++ b/gateways/ethereum/token.go
@@ -2,7 +2,9 @@ package ethereum
 
 import (
 	"context"
+	"math/big"
 
+	cmn "github.com/etheralley/etheralley-core-api/common"
 	"github.com/etheralley/etheralley-core-api/entities"
 	"github.com/etheralley/etheralley-core-api/gateways/ethereum/contracts"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -25,7 +27,7 @@ func (gw *gateway) GetFungibleBalance(ctx context.Context, address string, contr
 		return "", err
 	}
 
-	balance, err := instance.BalanceOf(&bind.CallOpts{}, adr)
+	balance, err := cmn.FunctionRetrier[*big.Int](ctx, gw.logger, instance.BalanceOf, &bind.CallOpts{}, adr)
 
 	if err != nil {
 		return "", err
@@ -49,7 +51,7 @@ func (gw *gateway) GetFungibleName(ctx context.Context, contract *entities.Contr
 		return
 	}
 
-	name, err = instance.Name(&bind.CallOpts{})
+	name, err = cmn.FunctionRetrier[string](ctx, gw.logger, instance.Name, &bind.CallOpts{})
 
 	return
 }
@@ -69,7 +71,7 @@ func (gw *gateway) GetFungibleSymbol(ctx context.Context, contract *entities.Con
 		return
 	}
 
-	symbol, err = instance.Symbol(&bind.CallOpts{})
+	symbol, err = cmn.FunctionRetrier[string](ctx, gw.logger, instance.Symbol, &bind.CallOpts{})
 
 	return
 }
@@ -89,7 +91,7 @@ func (gw *gateway) GetFungibleDecimals(ctx context.Context, contract *entities.C
 		return
 	}
 
-	decimals, err = instance.Decimals(&bind.CallOpts{})
+	decimals, err = cmn.FunctionRetrier[uint8](ctx, gw.logger, instance.Decimals, &bind.CallOpts{})
 
 	return
 }

--- a/gateways/redis/profile.go
+++ b/gateways/redis/profile.go
@@ -44,7 +44,7 @@ func (g *gateway) SaveProfile(ctx context.Context, profile *entities.Profile) er
 		return err
 	}
 
-	_, err = g.client.Set(ctx, getFullKey(ProfileNamespace, profile.Address), bytes, time.Hour*24).Result()
+	_, err = g.client.Set(ctx, getFullKey(ProfileNamespace, profile.Address), bytes, time.Hour).Result()
 
 	return err
 }

--- a/main.go
+++ b/main.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"math/rand"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/etheralley/etheralley-core-api/common"
 	"github.com/etheralley/etheralley-core-api/controllers"
@@ -63,6 +65,9 @@ func main() {
 	container.Provide(usecases.NewRefreshProfileUseCase)
 	container.Provide(httpPresenters.NewPresenter)
 	container.Provide(httpControllers.NewHttpController)
+
+	// seed the random number generator based on app start time
+	rand.Seed(time.Now().UnixNano())
 
 	// start controllers in concurrent go routines
 	err := container.Invoke(func(controller *httpControllers.HttpController) {


### PR DESCRIPTION
- introducing function retrier with exponential backoff to attempt to handle rate limiting by alchemy apis
- increasing timeout threshold
- fixing empty balance returned from alchemy nft api
- reducing profile cache time to an hour
