### PR TITLE
collection of refactorings

### DIFF
--- a/common/http.go
+++ b/common/http.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 )
@@ -46,8 +45,7 @@ func (c *httpClient) doInternal(ctx context.Context, method string, url string, 
 	req, err := http.NewRequestWithContext(ctx, method, url, nil)
 
 	if err != nil {
-		c.logger.Errf(ctx, err, "http err building request for url %v: ", url)
-		return nil, err
+		return nil, fmt.Errorf("http url %v", url)
 	}
 
 	if options != nil {
@@ -62,18 +60,15 @@ func (c *httpClient) doInternal(ctx context.Context, method string, url string, 
 	resp, err := c.client.Do(req)
 
 	if err != nil {
-		c.logger.Errf(ctx, err, "http err response for %v: ", url)
 		return nil, fmt.Errorf("http response err %w", err)
 	}
 
 	if resp.StatusCode == 429 {
-		c.logger.Errorf(ctx, "http rate-limit status code 429 for %v", url)
 		return nil, fmt.Errorf("http rate limit %w", ErrRetryable)
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
-		c.logger.Errorf(ctx, "http invalid status code %v for %v", resp.StatusCode, url)
-		return nil, errors.New(fmt.Sprintf("http invalid status code %v", resp.StatusCode))
+		return nil, fmt.Errorf("http invalid status code %v", resp.StatusCode)
 	}
 
 	return resp, nil

--- a/controllers/http/authenticate.go
+++ b/controllers/http/authenticate.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
@@ -15,7 +16,7 @@ func (hc *HttpController) authenticate(next http.Handler) http.Handler {
 		token := strings.Split(r.Header.Get("Authorization"), " ")
 
 		if len(token) != 2 || token[0] != "Bearer" {
-			hc.presenter.PresentUnathorized(w, r)
+			hc.presenter.PresentUnathorized(w, r, errors.New("invalid header format"))
 			return
 		}
 
@@ -25,7 +26,7 @@ func (hc *HttpController) authenticate(next http.Handler) http.Handler {
 		})
 
 		if err != nil {
-			hc.presenter.PresentUnathorized(w, r)
+			hc.presenter.PresentUnathorized(w, r, err)
 			return
 		}
 

--- a/gateways/alchemy/gateway.go
+++ b/gateways/alchemy/gateway.go
@@ -6,17 +6,15 @@ import (
 )
 
 type gateway struct {
-	settings    common.ISettings
-	logger      common.ILogger
-	graphClient common.IGraphQLClient
-	httpClient  common.IHttpClient
+	settings   common.ISettings
+	logger     common.ILogger
+	httpClient common.IHttpClient
 }
 
-func NewGateway(logger common.ILogger, settings common.ISettings, graphClient common.IGraphQLClient, httpClient common.IHttpClient) gateways.INFTAPIGateway {
+func NewGateway(logger common.ILogger, settings common.ISettings, httpClient common.IHttpClient) gateways.INFTAPIGateway {
 	return &gateway{
 		settings,
 		logger,
-		graphClient,
 		httpClient,
 	}
 }

--- a/gateways/ethereum/ens.go
+++ b/gateways/ethereum/ens.go
@@ -2,17 +2,18 @@ package ethereum
 
 import (
 	"context"
+	"fmt"
 
 	cmn "github.com/etheralley/etheralley-core-api/common"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/wealdtech/go-ens/v3"
 )
 
-func (gw *gateway) GetENSAddressFromName(ctx context.Context, name string) (address string, err error) {
+func (gw *gateway) GetENSAddressFromName(ctx context.Context, name string) (string, error) {
 	client, err := gw.getClient(ctx, cmn.ETHEREUM) // awlays use layer 1 for ens resolution
 
 	if err != nil {
-		return
+		return "", fmt.Errorf("ens building client %w", err)
 	}
 
 	adr, err := cmn.FunctionRetrier(ctx, func() (common.Address, error) {
@@ -21,19 +22,17 @@ func (gw *gateway) GetENSAddressFromName(ctx context.Context, name string) (addr
 	})
 
 	if err != nil {
-		return
+		return "", fmt.Errorf("get address from ens name %w", err)
 	}
 
-	address = adr.Hex()
-
-	return
+	return adr.Hex(), nil
 }
 
-func (gw *gateway) GetENSNameFromAddress(ctx context.Context, address string) (name string, err error) {
+func (gw *gateway) GetENSNameFromAddress(ctx context.Context, address string) (string, error) {
 	client, err := gw.getClient(ctx, cmn.ETHEREUM) // awlays use layer 1 for ens resolution
 
 	if err != nil {
-		return
+		return "", fmt.Errorf("ens building client %w", err)
 	}
 
 	return cmn.FunctionRetrier(ctx, func() (string, error) {

--- a/gateways/ethereum/gateway.go
+++ b/gateways/ethereum/gateway.go
@@ -36,7 +36,7 @@ func (gw *gateway) getClient(ctx context.Context, blockchain cmn.Blockchain) (*e
 	case cmn.ARBITRUM:
 		return ethclient.DialContext(ctx, gw.settings.ArbitrumURI())
 	}
-	return nil, errors.New("invalid blockchain provided")
+	return nil, fmt.Errorf("eth get client %v", blockchain)
 }
 
 // Parse for go-ethereum http error to determine if its retryable.

--- a/gateways/ethereum/token.go
+++ b/gateways/ethereum/token.go
@@ -2,6 +2,7 @@ package ethereum
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 
 	cmn "github.com/etheralley/etheralley-core-api/common"
@@ -15,7 +16,7 @@ func (gw *gateway) GetFungibleBalance(ctx context.Context, address string, contr
 	client, err := gw.getClient(ctx, contract.Blockchain)
 
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("erc20 balance client %w", err)
 	}
 
 	contractAddress := common.HexToAddress(contract.Address)
@@ -24,26 +25,26 @@ func (gw *gateway) GetFungibleBalance(ctx context.Context, address string, contr
 	instance, err := contracts.NewErc20(contractAddress, client)
 
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("erc20 balance contract %w", err)
 	}
 
 	balance, err := cmn.FunctionRetrier(ctx, func() (*big.Int, error) {
 		balance, err := instance.BalanceOf(&bind.CallOpts{}, adr)
-		return balance, tryWrapRetryable("get erc20 balance", err)
+		return balance, tryWrapRetryable("erc20 balance retry", err)
 	})
 
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("erc20 balance %w", err)
 	}
 
-	return balance.String(), err
+	return balance.String(), nil
 }
 
-func (gw *gateway) GetFungibleName(ctx context.Context, contract *entities.Contract) (name string, err error) {
+func (gw *gateway) GetFungibleName(ctx context.Context, contract *entities.Contract) (string, error) {
 	client, err := gw.getClient(ctx, contract.Blockchain)
 
 	if err != nil {
-		return
+		return "", fmt.Errorf("erc20 name client %w", err)
 	}
 
 	contractAddress := common.HexToAddress(contract.Address)
@@ -51,22 +52,26 @@ func (gw *gateway) GetFungibleName(ctx context.Context, contract *entities.Contr
 	instance, err := contracts.NewErc20(contractAddress, client)
 
 	if err != nil {
-		return
+		return "", fmt.Errorf("erc20 name contract %w", err)
 	}
 
-	name, err = cmn.FunctionRetrier(ctx, func() (string, error) {
+	name, err := cmn.FunctionRetrier(ctx, func() (string, error) {
 		name, err := instance.Name(&bind.CallOpts{})
-		return name, tryWrapRetryable("get erc20 name", err)
+		return name, tryWrapRetryable("erc20 name retry", err)
 	})
 
-	return
+	if err != nil {
+		return "", fmt.Errorf("erc20 name %w", err)
+	}
+
+	return name, nil
 }
 
-func (gw *gateway) GetFungibleSymbol(ctx context.Context, contract *entities.Contract) (symbol string, err error) {
+func (gw *gateway) GetFungibleSymbol(ctx context.Context, contract *entities.Contract) (string, error) {
 	client, err := gw.getClient(ctx, contract.Blockchain)
 
 	if err != nil {
-		return
+		return "", fmt.Errorf("erc20 symbol client %w", err)
 	}
 
 	contractAddress := common.HexToAddress(contract.Address)
@@ -74,22 +79,26 @@ func (gw *gateway) GetFungibleSymbol(ctx context.Context, contract *entities.Con
 	instance, err := contracts.NewErc20(contractAddress, client)
 
 	if err != nil {
-		return
+		return "", fmt.Errorf("erc20 symbol contract %w", err)
 	}
 
-	symbol, err = cmn.FunctionRetrier(ctx, func() (string, error) {
+	symbol, err := cmn.FunctionRetrier(ctx, func() (string, error) {
 		symbol, err := instance.Symbol(&bind.CallOpts{})
 		return symbol, tryWrapRetryable("get erc20 symbol", err)
 	})
 
-	return
+	if err != nil {
+		return "", fmt.Errorf("erc20 symbol %w", err)
+	}
+
+	return symbol, nil
 }
 
-func (gw *gateway) GetFungibleDecimals(ctx context.Context, contract *entities.Contract) (decimals uint8, err error) {
+func (gw *gateway) GetFungibleDecimals(ctx context.Context, contract *entities.Contract) (uint8, error) {
 	client, err := gw.getClient(ctx, contract.Blockchain)
 
 	if err != nil {
-		return
+		return 0, fmt.Errorf("erc20 decimals client %w", err)
 	}
 
 	contractAddress := common.HexToAddress(contract.Address)
@@ -97,13 +106,17 @@ func (gw *gateway) GetFungibleDecimals(ctx context.Context, contract *entities.C
 	instance, err := contracts.NewErc20(contractAddress, client)
 
 	if err != nil {
-		return
+		return 0, fmt.Errorf("erc20 decimals contract %w", err)
 	}
 
-	decimals, err = cmn.FunctionRetrier(ctx, func() (uint8, error) {
+	decimals, err := cmn.FunctionRetrier(ctx, func() (uint8, error) {
 		decimals, err := instance.Decimals(&bind.CallOpts{})
 		return decimals, tryWrapRetryable("get erc20 decimals", err)
 	})
 
-	return
+	if err != nil {
+		return 0, fmt.Errorf("erc20 decimals %w", err)
+	}
+
+	return decimals, nil
 }

--- a/gateways/gateway.go
+++ b/gateways/gateway.go
@@ -15,6 +15,7 @@ type IDatabaseGateway interface {
 type ICacheGateway interface {
 	GetProfileByAddress(ctx context.Context, address string) (*entities.Profile, error)
 	SaveProfile(ctx context.Context, profile *entities.Profile) error
+	DeleteProfile(ctx context.Context, address string) error
 
 	GetChallengeByAddress(ctx context.Context, address string) (*entities.Challenge, error)
 	SaveChallenge(ctx context.Context, challenge *entities.Challenge) error
@@ -41,7 +42,7 @@ type ICacheGateway interface {
 }
 
 type IBlockchainGateway interface {
-	GetNonFungibleMetadata(ctx context.Context, contract *entities.Contract, tokenId string) (*entities.NonFungibleMetadata, error)
+	GetNonFungibleURI(ctx context.Context, contract *entities.Contract, tokenId string) (string, error)
 	GetNonFungibleBalance(ctx context.Context, address string, contract *entities.Contract, tokenId string) (string, error)
 
 	GetFungibleBalance(ctx context.Context, address string, contract *entities.Contract) (string, error)
@@ -63,5 +64,6 @@ type IBlockchainIndexGateway interface {
 }
 
 type INFTAPIGateway interface {
-	GetNonFungibleTokens(ctx context.Context, address string) *[]entities.NonFungibleToken
+	GetNonFungibleMetadata(ctx context.Context, uri string) (*entities.NonFungibleMetadata, error)
+	GetNonFungibleTokens(ctx context.Context, address string) (*[]entities.NonFungibleToken, error)
 }

--- a/gateways/mongo/profile.go
+++ b/gateways/mongo/profile.go
@@ -2,6 +2,7 @@ package mongo
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/etheralley/etheralley-core-api/common"
 	"github.com/etheralley/etheralley-core-api/entities"
@@ -17,16 +18,16 @@ func (g *gateway) GetProfileByAddress(ctx context.Context, address string) (*ent
 	err := g.profiles.FindOne(ctx, bson.D{primitive.E{Key: "_id", Value: address}}).Decode(profileBson)
 
 	if err == mongo.ErrNoDocuments {
-		return nil, common.ErrNotFound
+		return nil, fmt.Errorf("profile not found %w", common.ErrNotFound)
 	}
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get profile %w", err)
 	}
 
 	profile := fromProfileBson(profileBson)
 
-	return profile, err
+	return profile, nil
 }
 
 func (g *gateway) SaveProfile(ctx context.Context, profile *entities.Profile) error {
@@ -34,5 +35,9 @@ func (g *gateway) SaveProfile(ctx context.Context, profile *entities.Profile) er
 
 	_, err := g.profiles.UpdateOne(ctx, bson.D{primitive.E{Key: "_id", Value: profile.Address}}, bson.D{primitive.E{Key: "$set", Value: profileBson}}, options.Update().SetUpsert(true))
 
-	return err
+	if err != nil {
+		return fmt.Errorf("save profile %w", err)
+	}
+
+	return nil
 }

--- a/gateways/redis/challenge.go
+++ b/gateways/redis/challenge.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/etheralley/etheralley-core-api/entities"
@@ -12,11 +13,19 @@ const ChallengeNamespace = "challenge"
 func (g *gateway) GetChallengeByAddress(ctx context.Context, address string) (*entities.Challenge, error) {
 	msg, err := g.client.Get(ctx, getFullKey(ChallengeNamespace, address)).Result()
 
-	return &entities.Challenge{Address: address, Message: msg}, err
+	if err != nil {
+		return nil, fmt.Errorf("get challenge %w", err)
+	}
+
+	return &entities.Challenge{Address: address, Message: msg}, nil
 }
 
 func (g *gateway) SaveChallenge(ctx context.Context, challenge *entities.Challenge) error {
 	_, err := g.client.Set(ctx, getFullKey(ChallengeNamespace, challenge.Address), challenge.Message, time.Minute*5).Result()
 
-	return err
+	if err != nil {
+		return fmt.Errorf("save challenge %w", err)
+	}
+
+	return nil
 }

--- a/gateways/redis/ens.go
+++ b/gateways/redis/ens.go
@@ -2,25 +2,48 @@ package redis
 
 import (
 	"context"
+	"fmt"
 	"time"
 )
 
 const ENSNamespace = "ens"
 
 func (g *gateway) GetENSAddressFromName(ctx context.Context, ensName string) (string, error) {
-	return g.client.Get(ctx, getFullKey(ENSNamespace, ensName)).Result()
+	address, err := g.client.Get(ctx, getFullKey(ENSNamespace, ensName)).Result()
+
+	if err != nil {
+		return "", fmt.Errorf("get ens address %w", err)
+	}
+
+	return address, nil
 }
 
 func (g *gateway) SaveENSAddress(ctx context.Context, ensName string, address string) error {
 	_, err := g.client.Set(ctx, getFullKey(ENSNamespace, ensName), address, time.Hour*24).Result()
-	return err
+
+	if err != nil {
+		return fmt.Errorf("save ens address %w", err)
+	}
+
+	return nil
 }
 
 func (g *gateway) GetENSNameFromAddress(ctx context.Context, address string) (string, error) {
-	return g.client.Get(ctx, getFullKey(ENSNamespace, address)).Result()
+	name, err := g.client.Get(ctx, getFullKey(ENSNamespace, address)).Result()
+
+	if err != nil {
+		return "", fmt.Errorf("get ens name %w", err)
+	}
+
+	return name, nil
 }
 
 func (g *gateway) SaveENSName(ctx context.Context, address string, name string) error {
 	_, err := g.client.Set(ctx, getFullKey(ENSNamespace, address), name, time.Hour*24).Result()
-	return err
+
+	if err != nil {
+		return fmt.Errorf("save ens name %w", err)
+	}
+
+	return nil
 }

--- a/gateways/redis/listings.go
+++ b/gateways/redis/listings.go
@@ -3,6 +3,7 @@ package redis
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -16,14 +17,14 @@ func (g *gateway) GetStoreListings(ctx context.Context, tokenIds *[]string) (*[]
 	listingsString, err := g.client.Get(ctx, getFullKey(ListingsNamespace, strings.Join(*tokenIds, "_"))).Result()
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get listings %w", err)
 	}
 
 	listingsJson := &[]listingJson{}
 	err = json.Unmarshal([]byte(listingsString), listingsJson)
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get listings decoded %w", err)
 	}
 
 	listings := fromListingsJson(listingsJson)
@@ -36,7 +37,7 @@ func (g *gateway) SaveStoreListings(ctx context.Context, listings *[]entities.Li
 	bytes, err := json.Marshal(listingsJson)
 
 	if err != nil {
-		return err
+		return fmt.Errorf("save listings encode %w", err)
 	}
 
 	tokenIds := []string{}
@@ -46,5 +47,9 @@ func (g *gateway) SaveStoreListings(ctx context.Context, listings *[]entities.Li
 
 	_, err = g.client.Set(ctx, getFullKey(ListingsNamespace, strings.Join(tokenIds, "_")), bytes, time.Hour).Result()
 
-	return err
+	if err != nil {
+		return fmt.Errorf("save listings %w", err)
+	}
+
+	return nil
 }

--- a/gateways/redis/nft.go
+++ b/gateways/redis/nft.go
@@ -3,6 +3,7 @@ package redis
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/etheralley/etheralley-core-api/entities"
@@ -15,14 +16,14 @@ func (g *gateway) GetNonFungibleMetadata(ctx context.Context, contract *entities
 	metadataString, err := g.client.Get(ctx, getFullKey(NFTNamespace, contract.Address, tokenId, contract.Blockchain)).Result()
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get nft metadata %w", err)
 	}
 
 	metadataJson := &nonFungibleMetadataJson{}
 	err = json.Unmarshal([]byte(metadataString), metadataJson)
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode nft metadata %w", err)
 	}
 
 	metadata := fromNonFungibleMetadataJson(metadataJson)
@@ -35,10 +36,14 @@ func (g *gateway) SaveNonFungibleMetadata(ctx context.Context, contract *entitie
 	bytes, err := json.Marshal(metadataJson)
 
 	if err != nil {
-		return err
+		return fmt.Errorf("encode nft metadata %w", err)
 	}
 
 	_, err = g.client.Set(ctx, getFullKey(NFTNamespace, contract.Address, tokenId, contract.Blockchain), bytes, time.Hour).Result()
 
-	return err
+	if err != nil {
+		return fmt.Errorf("save nft metadata  %w", err)
+	}
+
+	return nil
 }

--- a/gateways/redis/profile.go
+++ b/gateways/redis/profile.go
@@ -3,6 +3,7 @@ package redis
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/etheralley/etheralley-core-api/common"
@@ -16,18 +17,18 @@ func (g *gateway) GetProfileByAddress(ctx context.Context, address string) (*ent
 	profileString, err := g.client.Get(ctx, getFullKey(ProfileNamespace, address)).Result()
 
 	if err == redis.Nil {
-		return nil, common.ErrNotFound
+		return nil, fmt.Errorf("profile not found %w", common.ErrNotFound)
 	}
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get profile %w", err)
 	}
 
 	profJson := &profileJson{}
 	err = json.Unmarshal([]byte(profileString), profJson)
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode profile %w", err)
 	}
 
 	profile := fromProfileJson(profJson)
@@ -41,10 +42,24 @@ func (g *gateway) SaveProfile(ctx context.Context, profile *entities.Profile) er
 	bytes, err := json.Marshal(profJson)
 
 	if err != nil {
-		return err
+		return fmt.Errorf("encode profile %w", err)
 	}
 
 	_, err = g.client.Set(ctx, getFullKey(ProfileNamespace, profile.Address), bytes, time.Hour).Result()
 
-	return err
+	if err != nil {
+		return fmt.Errorf("save profile %w", err)
+	}
+
+	return nil
+}
+
+func (g *gateway) DeleteProfile(ctx context.Context, address string) error {
+	err := g.client.Del(ctx, getFullKey(ProfileNamespace, address)).Err()
+
+	if err != nil {
+		return fmt.Errorf("delete profile %w", err)
+	}
+
+	return nil
 }

--- a/gateways/redis/token.go
+++ b/gateways/redis/token.go
@@ -3,6 +3,7 @@ package redis
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/etheralley/etheralley-core-api/entities"
@@ -15,14 +16,14 @@ func (g *gateway) GetFungibleMetadata(ctx context.Context, contract *entities.Co
 	metadataString, err := g.client.Get(ctx, getFullKey(TokenNamespace, contract.Address, contract.Blockchain)).Result()
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get fungible metadata %w", err)
 	}
 
 	metadataJson := &fungibleMetadataJson{}
 	err = json.Unmarshal([]byte(metadataString), metadataJson)
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode fungible metadata %w", err)
 	}
 
 	metadata := fromFungibleMetadataJson(metadataJson)
@@ -35,10 +36,14 @@ func (g *gateway) SaveFungibleMetadata(ctx context.Context, contract *entities.C
 	bytes, err := json.Marshal(metadataJson)
 
 	if err != nil {
-		return err
+		return fmt.Errorf("encode fungible metadata %w", err)
 	}
 
 	_, err = g.client.Set(ctx, getFullKey(TokenNamespace, contract.Address, contract.Blockchain), bytes, time.Hour*24).Result()
 
-	return err
+	if err != nil {
+		return fmt.Errorf("save fungible metadata %w", err)
+	}
+
+	return nil
 }

--- a/gateways/thegraph/gateway.go
+++ b/gateways/thegraph/gateway.go
@@ -1,7 +1,6 @@
 package thegraph
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/etheralley/etheralley-core-api/common"
@@ -55,5 +54,5 @@ func (gw gateway) getSubgraphUrl(b common.Blockchain, i common.Interface) (strin
 		}
 	}
 
-	return "", errors.New("unsupported interface blockchain combination")
+	return "", fmt.Errorf("subgraph url %v %v", b, i)
 }

--- a/gateways/thegraph/swaps.go
+++ b/gateways/thegraph/swaps.go
@@ -2,6 +2,7 @@ package thegraph
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/etheralley/etheralley-core-api/entities"
 )
@@ -50,8 +51,7 @@ func (gw *gateway) GetSwaps(ctx context.Context, address string, contract *entit
 	url, err := gw.getSubgraphUrl(contract.Blockchain, contract.Interface)
 
 	if err != nil {
-		gw.logger.Err(ctx, err, "error building subgraph url")
-		return nil, err
+		return nil, fmt.Errorf("swaps url %w", err)
 	}
 
 	query := &swapsQuery{}
@@ -61,8 +61,7 @@ func (gw *gateway) GetSwaps(ctx context.Context, address string, contract *entit
 	err = gw.graphClient.Query(ctx, url, query, variables)
 
 	if err != nil {
-		gw.logger.Err(ctx, err, "error calling subgraph")
-		return nil, err
+		return nil, fmt.Errorf("swaps query %w", err)
 	}
 
 	swaps := []swapJson{}

--- a/presenters/http/errors.go
+++ b/presenters/http/errors.go
@@ -9,8 +9,8 @@ func (p *httpPresenter) PresentBadRequest(w http.ResponseWriter, r *http.Request
 	p.presentJSON(w, r, http.StatusBadRequest, toErrJson("bad request"))
 }
 
-func (p *httpPresenter) PresentUnathorized(w http.ResponseWriter, r *http.Request) {
-	p.logger.Error(r.Context(), "unauthorized err")
+func (p *httpPresenter) PresentUnathorized(w http.ResponseWriter, r *http.Request, err error) {
+	p.logger.Err(r.Context(), err, "unauthorized err")
 	p.presentJSON(w, r, http.StatusUnauthorized, toErrJson("unathorized"))
 }
 

--- a/presenters/presenter.go
+++ b/presenters/presenter.go
@@ -8,7 +8,7 @@ import (
 
 type IPresenter interface {
 	PresentBadRequest(http.ResponseWriter, *http.Request, error)
-	PresentUnathorized(http.ResponseWriter, *http.Request)
+	PresentUnathorized(http.ResponseWriter, *http.Request, error)
 	PresentHealth(http.ResponseWriter, *http.Request)
 	PresentChallenge(http.ResponseWriter, *http.Request, *entities.Challenge)
 	PresentFungibleToken(http.ResponseWriter, *http.Request, *entities.FungibleToken)

--- a/usecases/get_all_interactions.go
+++ b/usecases/get_all_interactions.go
@@ -14,21 +14,22 @@ type GetAllInteractionsInput struct {
 
 // Get all interactions
 //
-// Invalid Interactions are removed from the returned slice
-type IGetAllInteractionsUseCase func(ctx context.Context, input *GetAllInteractionsInput) *[]entities.Interaction
+// A non nil error will be returned if any interactions in the list are invalid
+type IGetAllInteractionsUseCase func(ctx context.Context, input *GetAllInteractionsInput) (*[]entities.Interaction, error)
 
 func NewGetAllInteractionsUseCase(
 	logger common.ILogger,
 	getInteraction IGetInteractionUseCase,
 ) IGetAllInteractionsUseCase {
-	return func(ctx context.Context, input *GetAllInteractionsInput) *[]entities.Interaction {
+	return func(ctx context.Context, input *GetAllInteractionsInput) (*[]entities.Interaction, error) {
 		if err := common.ValidateStruct(input); err != nil {
-			return &[]entities.Interaction{}
+			return nil, err
 		}
 
 		var wg sync.WaitGroup
+		var interactionErr error
+		interactions := make([]entities.Interaction, len(*input.Interactions))
 
-		interactions := make([]*entities.Interaction, len(*input.Interactions))
 		for i, intrInput := range *input.Interactions {
 			wg.Add(1)
 
@@ -38,24 +39,22 @@ func NewGetAllInteractionsUseCase(
 				interaction, err := getInteraction(ctx, &intr)
 
 				if err != nil {
-					logger.Errf(ctx, err, "invalid input: transaction id %v blockchain %v type %v address %v", intr.Interaction.Transaction.Id, intr.Interaction.Transaction.Blockchain, intr.Interaction.Type, intr.Address)
+					logger.Errf(ctx, err, "invalid interaction: transaction id %v blockchain %v type %v address %v", intr.Interaction.Transaction.Id, intr.Interaction.Transaction.Blockchain, intr.Interaction.Type, intr.Address)
+					interactionErr = err
 					return
 				}
 
-				interactions[i] = interaction
+				interactions[i] = *interaction
 
 			}(i, intrInput)
 		}
 
 		wg.Wait()
 
-		trimmedInteractions := []entities.Interaction{}
-		for _, interaction := range interactions {
-			if interaction != nil {
-				trimmedInteractions = append(trimmedInteractions, *interaction)
-			}
+		if interactionErr != nil {
+			return nil, interactionErr
 		}
 
-		return &trimmedInteractions
+		return &interactions, nil
 	}
 }

--- a/usecases/get_profile.go
+++ b/usecases/get_profile.go
@@ -2,6 +2,7 @@ package usecases
 
 import (
 	"context"
+	"errors"
 	"math/big"
 	"sync"
 
@@ -48,7 +49,7 @@ func NewGetProfile(
 
 		profile, err = databaseGateway.GetProfileByAddress(ctx, input.Address)
 
-		if err == common.ErrNotFound {
+		if errors.Is(err, common.ErrNotFound) {
 			logger.Debugf(ctx, "db miss for profile %v", input.Address)
 
 			profile, err := getDefaultProfile(ctx, &GetDefaultProfileInput{


### PR DESCRIPTION
- adding context to gateway errors and removing logging
- moved nft metadata fetching to api gateway
- adding explicit error to get all nfts gateway function
- adding some missed error handling
- no longer dropping interactions that errored. instead failing the profile save if there are issues with any interactions since they are not transient. no longer hydrating the whole profile on save to just refresh the cache. instead deleting the cached profile. Can be re-cached on the next page visit.