### PR TITLE
removing untrusted header from real ip parser and getting image url from alchemy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env*
 bin
+__debug_bin

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,9 @@
       "mode": "debug",
       "remotePath": "",
       "program": "${workspaceRoot}",
-      "env": {},
+      "env": {
+        "ENV": "dev"
+      },
       "args": [],
       "showLog": true
     }

--- a/controllers/http/real_ip.go
+++ b/controllers/http/real_ip.go
@@ -5,19 +5,16 @@ import (
 	"strings"
 )
 
-var trueClientIP = http.CanonicalHeaderKey("True-Client-IP")
 var xForwardedFor = http.CanonicalHeaderKey("X-Forwarded-For")
 var xRealIP = http.CanonicalHeaderKey("X-Real-IP")
 
 const localhost = "127.0.0.1"
 
-// TODO: Ideally these headers can be trusted from the load balancer of the cloud provider we settle on. Need to investigate if this is true once deployed
-//
 // See https://github.com/go-chi/chi/blob/master/middleware/realip.go
 func (hc *HttpController) realIP(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// RemoteAddr is not in a recognizable format on dev without the 3 headers above
-		// This makes things like recording profile views a little more pleasant on local while keep validation in place
+		// This makes things like recording profile views a little more pleasant on local while keeping validation in place
 		if hc.settings.IsDev() {
 			r.RemoteAddr = localhost
 		} else if rip := getIP(r); rip != "" {
@@ -28,9 +25,7 @@ func (hc *HttpController) realIP(h http.Handler) http.Handler {
 }
 
 func getIP(r *http.Request) string {
-	if tcip := r.Header.Get(trueClientIP); tcip != "" {
-		return tcip
-	} else if xrip := r.Header.Get(xRealIP); xrip != "" {
+	if xrip := r.Header.Get(xRealIP); xrip != "" {
 		return xrip
 	} else if xff := r.Header.Get(xForwardedFor); xff != "" {
 		i := strings.Index(xff, ", ")

--- a/gateways/offchain/nfts.go
+++ b/gateways/offchain/nfts.go
@@ -25,6 +25,7 @@ type responseJson struct {
 			Name        string                    `json:"name"`
 			Description string                    `json:"description"`
 			Image       string                    `json:"image"`
+			ImageURL    string                    `json:"image_url"`
 			Attributes  *[]map[string]interface{} `json:"attributes"`
 		}
 	} `json:"ownedNfts"`
@@ -57,6 +58,15 @@ func (gw *gateway) GetNonFungibleTokens(ctx context.Context, address string) (*[
 	}
 	for _, nftJson := range respJson.OwnedNFTs[:cutoff] {
 		balance := "1"
+
+		image := ""
+		if nftJson.Metadata.Image != "" {
+			image = nftJson.Metadata.Image
+		} else if nftJson.Metadata.ImageURL != "" {
+			image = nftJson.Metadata.ImageURL
+		}
+		image = gw.replaceIPFSScheme(image)
+
 		nft := entities.NonFungibleToken{
 			TokenId: nftJson.Id.TokenId,
 			Balance: &balance, // TODO: Doesn't appear that a balance is provided by alchemy for ERC1155, only ERC721...
@@ -68,7 +78,7 @@ func (gw *gateway) GetNonFungibleTokens(ctx context.Context, address string) (*[
 			Metadata: &entities.NonFungibleMetadata{
 				Name:        nftJson.Metadata.Name,
 				Description: nftJson.Metadata.Description,
-				Image:       gw.replaceIPFSScheme(nftJson.Metadata.Image),
+				Image:       image,
 				Attributes:  nftJson.Metadata.Attributes,
 			},
 		}


### PR DESCRIPTION
- True-Client-IP doesn't appear to be trustworthy based on some testing with our reverse proxy
- image url is sometimes specified instead of image on nft metadata and we should thus parse it out when calling alchemy to get all nfts