### PR TITLE
fixing realIP middleware

### DIFF
--- a/controllers/http/real_ip.go
+++ b/controllers/http/real_ip.go
@@ -1,49 +1,57 @@
 package http
 
 import (
+	"net"
 	"net/http"
 	"strings"
 )
 
-var trueClientIP = http.CanonicalHeaderKey("True-Client-IP")
 var xForwardedFor = http.CanonicalHeaderKey("X-Forwarded-For")
-var xRealIP = http.CanonicalHeaderKey("X-Real-IP")
-
-const localhost = "127.0.0.1"
 
 // See https://github.com/go-chi/chi/blob/master/middleware/realip.go
 func (hc *HttpController) realIP(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		tcip := r.Header.Get(trueClientIP)
-		xRealIP := r.Header.Get(xRealIP)
-		xForwardedFor := r.Header.Get(xForwardedFor)
-		hc.logger.Info(r.Context()).Msgf("tcip: %v", tcip)
-		hc.logger.Info(r.Context()).Msgf("realip: %v", xRealIP)
-		hc.logger.Info(r.Context()).Msgf("xff: %v", xForwardedFor)
+		hc.logger.Info(r.Context()).Msgf("x-forwarded-for: %v", xForwardedFor)
+		hc.logger.Info(r.Context()).Msgf("remoteaddr before: %v", r.RemoteAddr)
 
-		// RemoteAddr is not in a recognizable format on dev without the 3 headers above
-		// This makes things like recording profile views a little more pleasant on local while keeping validation in place
-		if hc.settings.IsDev() {
-			r.RemoteAddr = localhost
-		} else if rip := getIP(r); rip != "" {
-			r.RemoteAddr = rip
+		if ip := getIP(r); ip != "" {
+			r.RemoteAddr = ip
 		}
 
-		hc.logger.Info(r.Context()).Msgf("remoteaddr: %v", r.RemoteAddr)
+		if host, err := parseIP(r); err == nil {
+			r.RemoteAddr = host
+		}
+
+		hc.logger.Info(r.Context()).Msgf("remoteaddr after: %v", r.RemoteAddr)
 
 		h.ServeHTTP(w, r)
 	})
 }
 
-func getIP(r *http.Request) string {
-	if xrip := r.Header.Get(xRealIP); xrip != "" {
-		return xrip
-	} else if xff := r.Header.Get(xForwardedFor); xff != "" {
-		i := strings.Index(xff, ", ")
-		if i == -1 {
-			i = len(xff)
-		}
-		return xff[:i]
+// if xff header present, pick last addr in comma delimited list
+func getIP(r *http.Request) (ip string) {
+	xff := r.Header.Get(xForwardedFor)
+
+	if xff == "" {
+		return ""
 	}
-	return ""
+
+	i := strings.LastIndex(xff, ", ")
+
+	if i+2 >= len(xff) {
+		return ""
+	}
+
+	if i == -1 {
+		return xff
+	}
+
+	return xff[i+2:]
+}
+
+// validate the ip format
+// parse the host out of the ip addr
+func parseIP(r *http.Request) (string, error) {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	return host, err
 }


### PR DESCRIPTION
- Based on current reverse proxy, the only ip header we should trust is x-forwarded-for
- Taking the last address in the comma delimited list. Earlier addresses can be spoofed.
- Removing the port from the address