### PR TITLE
nft parse fix and log on blockchain rate limit

### DIFF
--- a/gateways/ethereum/ens.go
+++ b/gateways/ethereum/ens.go
@@ -18,7 +18,7 @@ func (gw *gateway) GetENSAddressFromName(ctx context.Context, name string) (stri
 
 	adr, err := cmn.FunctionRetrier(ctx, func() (common.Address, error) {
 		adr, err := ens.Resolve(client, name)
-		return adr, tryWrapRetryable("get address from ens name", err)
+		return adr, gw.tryWrapRetryable(ctx, "get address from ens name", err)
 	})
 
 	if err != nil {
@@ -37,6 +37,6 @@ func (gw *gateway) GetENSNameFromAddress(ctx context.Context, address string) (s
 
 	return cmn.FunctionRetrier(ctx, func() (string, error) {
 		name, err := ens.ReverseResolve(client, common.HexToAddress(address))
-		return name, tryWrapRetryable("get ens name from address", err)
+		return name, gw.tryWrapRetryable(ctx, "get ens name from address", err)
 	})
 }

--- a/gateways/ethereum/gateway.go
+++ b/gateways/ethereum/gateway.go
@@ -40,16 +40,16 @@ func (gw *gateway) getClient(ctx context.Context, blockchain cmn.Blockchain) (*e
 }
 
 // Parse for go-ethereum http error to determine if its retryable.
-// Wrap in common.ErrRetryable if status code is 429
-// and add context
-func tryWrapRetryable(context string, err error) error {
+// Wrap in common.ErrRetryable if status code is 429 and include msg
+func (gw *gateway) tryWrapRetryable(ctx context.Context, msg string, err error) error {
 	if err == nil {
 		return nil
 	}
 
 	var e rpc.HTTPError
 	if errors.As(err, &e) && e.StatusCode == 429 {
-		return fmt.Errorf("%v %v %w", context, err, cmn.ErrRetryable)
+		gw.logger.Warn(ctx).Err(err).Msgf("eth rate limit: %v", msg)
+		return fmt.Errorf("%v %v %w", msg, err, cmn.ErrRetryable)
 	}
 
 	return err

--- a/gateways/ethereum/nft.go
+++ b/gateways/ethereum/nft.go
@@ -39,7 +39,7 @@ func (gw *gateway) GetERC1155Balance(ctx context.Context, address string, contra
 
 	balance, err := cmn.FunctionRetrier(ctx, func() (*big.Int, error) {
 		balance, err := instance.BalanceOf(&bind.CallOpts{}, adr, id)
-		return balance, tryWrapRetryable("erc1155 balance retry", err)
+		return balance, gw.tryWrapRetryable(ctx, "erc1155 balance retry", err)
 	})
 
 	// treat a bad contract address as a zero balance
@@ -78,7 +78,7 @@ func (gw *gateway) GetERC721Balance(ctx context.Context, address string, contrac
 
 	owner, err := cmn.FunctionRetrier(ctx, func() (common.Address, error) {
 		owner, err := instance.OwnerOf(&bind.CallOpts{}, id)
-		return owner, tryWrapRetryable("erc721 balance retry", err)
+		return owner, gw.tryWrapRetryable(ctx, "erc721 balance retry", err)
 	})
 
 	// treat a bad contract address as a zero balance
@@ -120,7 +120,7 @@ func (gw *gateway) GetERC1155URI(ctx context.Context, contract *entities.Contrac
 
 	uri, err := cmn.FunctionRetrier(ctx, func() (string, error) {
 		uri, err := instance.Uri(&bind.CallOpts{}, id)
-		return uri, tryWrapRetryable("erc1155 uri retry", err)
+		return uri, gw.tryWrapRetryable(ctx, "erc1155 uri retry", err)
 	})
 
 	if err != nil {
@@ -157,6 +157,6 @@ func (gw *gateway) GetERC721URI(ctx context.Context, contract *entities.Contract
 
 	return cmn.FunctionRetrier(ctx, func() (string, error) {
 		uri, err := instance.TokenURI(&bind.CallOpts{}, id)
-		return uri, tryWrapRetryable("erc721 uri retry", err)
+		return uri, gw.tryWrapRetryable(ctx, "erc721 uri retry", err)
 	})
 }

--- a/gateways/ethereum/punk.go
+++ b/gateways/ethereum/punk.go
@@ -37,7 +37,7 @@ func (gw *gateway) GetPunkBalance(ctx context.Context, address string, contract 
 
 	owner, err := cmn.FunctionRetrier(ctx, func() (common.Address, error) {
 		owner, err := instance.PunkIndexToAddress(&bind.CallOpts{}, id)
-		return owner, tryWrapRetryable("punk balanceOf retry", err)
+		return owner, gw.tryWrapRetryable(ctx, "punk balanceOf retry", err)
 	})
 
 	// treat a bad contract address as a zero balance

--- a/gateways/ethereum/store.go
+++ b/gateways/ethereum/store.go
@@ -42,7 +42,7 @@ func (gw *gateway) GetStoreListingInfo(ctx context.Context, ids *[]string) (*[]e
 
 	listingsArr, err := cmn.FunctionRetrier(ctx, func() ([]contracts.IEtherAlleyStoreTokenListing, error) {
 		listingsArr, err := instance.GetListingBatch(&bind.CallOpts{}, idsArr)
-		return listingsArr, tryWrapRetryable("listing info retry", err)
+		return listingsArr, gw.tryWrapRetryable(ctx, "listing info retry", err)
 	})
 
 	if err != nil {
@@ -97,6 +97,6 @@ func (gw *gateway) GetStoreBalanceBatch(ctx context.Context, address string, ids
 
 	return cmn.FunctionRetrier(ctx, func() ([]*big.Int, error) {
 		balences, err := instance.BalanceOfBatch(&bind.CallOpts{}, accountsArr, idsArr)
-		return balences, tryWrapRetryable("balance batch retry", err)
+		return balences, gw.tryWrapRetryable(ctx, "balance batch retry", err)
 	})
 }

--- a/gateways/ethereum/token.go
+++ b/gateways/ethereum/token.go
@@ -30,7 +30,7 @@ func (gw *gateway) GetERC20Balance(ctx context.Context, address string, contract
 
 	balance, err := cmn.FunctionRetrier(ctx, func() (*big.Int, error) {
 		balance, err := instance.BalanceOf(&bind.CallOpts{}, adr)
-		return balance, tryWrapRetryable("erc20 balance retry", err)
+		return balance, gw.tryWrapRetryable(ctx, "erc20 balance retry", err)
 	})
 
 	if err != nil {
@@ -57,7 +57,7 @@ func (gw *gateway) GetERC20Name(ctx context.Context, contract *entities.Contract
 
 	name, err := cmn.FunctionRetrier(ctx, func() (string, error) {
 		name, err := instance.Name(&bind.CallOpts{})
-		return name, tryWrapRetryable("erc20 name retry", err)
+		return name, gw.tryWrapRetryable(ctx, "erc20 name retry", err)
 	})
 
 	if err != nil {
@@ -84,7 +84,7 @@ func (gw *gateway) GetERC20Symbol(ctx context.Context, contract *entities.Contra
 
 	symbol, err := cmn.FunctionRetrier(ctx, func() (string, error) {
 		symbol, err := instance.Symbol(&bind.CallOpts{})
-		return symbol, tryWrapRetryable("erc20 symbol retry", err)
+		return symbol, gw.tryWrapRetryable(ctx, "erc20 symbol retry", err)
 	})
 
 	if err != nil {
@@ -111,7 +111,7 @@ func (gw *gateway) GetERC20Decimals(ctx context.Context, contract *entities.Cont
 
 	decimals, err := cmn.FunctionRetrier(ctx, func() (uint8, error) {
 		decimals, err := instance.Decimals(&bind.CallOpts{})
-		return decimals, tryWrapRetryable("erc20 decimals retry", err)
+		return decimals, gw.tryWrapRetryable(ctx, "erc20 decimals retry", err)
 	})
 
 	if err != nil {

--- a/gateways/ethereum/transaction.go
+++ b/gateways/ethereum/transaction.go
@@ -38,7 +38,7 @@ func (gw *gateway) GetTransactionData(ctx context.Context, transaction *entities
 				return nil, fmt.Errorf("tx is pending %w", cmn.ErrRetryable)
 			}
 
-			return tx, tryWrapRetryable("tx retry", err)
+			return tx, gw.tryWrapRetryable(ctx, "tx retry", err)
 		})
 	}()
 
@@ -47,7 +47,7 @@ func (gw *gateway) GetTransactionData(ctx context.Context, transaction *entities
 
 		txRct, err := cmn.FunctionRetrier(ctx, func() (*types.Receipt, error) {
 			txRct, err := client.TransactionReceipt(ctx, hash)
-			return txRct, tryWrapRetryable("tx receipt retry", err)
+			return txRct, gw.tryWrapRetryable(ctx, "tx receipt retry", err)
 		})
 
 		if err != nil {


### PR DESCRIPTION
- nft metadata from alchemy api can come in either struct or string and parsing fails completely when we encounter these scenarios. The solution is to leave the metadata raw and parse it individually when looping through the nfts.
- adding a warning log when we encounter rate limiting errors for better visibility