### PR TITLE
adding banned/lastmodified fields to profile

### DIFF
--- a/controllers/http/profile.go
+++ b/controllers/http/profile.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/etheralley/etheralley-core-api/common"
@@ -18,6 +19,11 @@ func (hc *HttpController) getProfileByAddressRoute(w http.ResponseWriter, r *htt
 
 	if err != nil {
 		hc.presenter.PresentBadRequest(w, r, err)
+		return
+	}
+
+	if profile.Banned {
+		hc.presenter.PresentForbiddenRequest(w, r, fmt.Errorf("banned profile"))
 		return
 	}
 

--- a/entities/profile.go
+++ b/entities/profile.go
@@ -1,10 +1,14 @@
 package entities
 
+import "time"
+
 type Profile struct {
 	Address           string
+	Banned            bool
+	LastModified      *time.Time // LastModified can be nil if this is a defaul profile
 	ENSName           string
 	StoreAssets       *StoreAssets
-	DisplayConfig     *DisplayConfig // DisplayConfig can be nil
+	DisplayConfig     *DisplayConfig // DisplayConfig can be nil if this is a default profile
 	NonFungibleTokens *[]NonFungibleToken
 	FungibleTokens    *[]FungibleToken
 	Statistics        *[]Statistic

--- a/gateways/mongo/gateway.go
+++ b/gateways/mongo/gateway.go
@@ -2,6 +2,7 @@ package mongo
 
 import (
 	"context"
+	"time"
 
 	"github.com/etheralley/etheralley-core-api/common"
 	"github.com/etheralley/etheralley-core-api/entities"
@@ -41,6 +42,8 @@ func (gw *gateway) Init() {
 
 type profileBson struct {
 	Address           string                  `bson:"_id"`
+	Banned            bool                    `bson:"banned,omitempty"`
+	LastModified      *time.Time              `bson:"last_modified"`
 	DisplayConfig     *displayConfigBson      `bson:"display_config"`
 	NonFungibleTokens *[]nonFungibleTokenBson `bson:"non_fungible_tokens"`
 	FungibleTokens    *[]fungibleTokenBson    `bson:"fungible_tokens"`
@@ -250,6 +253,8 @@ func fromProfileBson(profileBson *profileBson) *entities.Profile {
 
 	return &entities.Profile{
 		Address:           profileBson.Address,
+		Banned:            profileBson.Banned,
+		LastModified:      profileBson.LastModified,
 		DisplayConfig:     &config,
 		NonFungibleTokens: &nfts,
 		FungibleTokens:    &tokens,
@@ -373,8 +378,10 @@ func toProfileBson(profile *entities.Profile) *profileBson {
 		config.Groups = &groups
 	}
 
+	lastModified := time.Now().UTC()
 	return &profileBson{
 		Address:           profile.Address,
+		LastModified:      &lastModified,
 		DisplayConfig:     &config,
 		NonFungibleTokens: &nfts,
 		FungibleTokens:    &tokens,

--- a/gateways/redis/gateway.go
+++ b/gateways/redis/gateway.go
@@ -3,6 +3,7 @@ package redis
 import (
 	"crypto/tls"
 	"strings"
+	"time"
 
 	"github.com/etheralley/etheralley-core-api/common"
 	"github.com/etheralley/etheralley-core-api/entities"
@@ -49,6 +50,8 @@ func getFullKey(keys ...string) string {
 
 type profileJson struct {
 	Address           string                  `json:"address"`
+	Banned            bool                    `json:"banned"`
+	LastModified      *time.Time              `json:"last_modified"`
 	ENSName           string                  `json:"ens_name"`
 	DisplayConfig     *displayConfigJson      `json:"display_config,omitempty"`
 	StoreAssets       *storeAssetsJson        `json:"store_assets"`
@@ -320,8 +323,10 @@ func fromProfileJson(profileJson *profileJson) *entities.Profile {
 	}
 
 	return &entities.Profile{
-		Address: profileJson.Address,
-		ENSName: profileJson.ENSName,
+		Address:      profileJson.Address,
+		Banned:       profileJson.Banned,
+		LastModified: profileJson.LastModified,
+		ENSName:      profileJson.ENSName,
 		StoreAssets: &entities.StoreAssets{
 			Premium:    profileJson.StoreAssets.Premium,
 			BetaTester: profileJson.StoreAssets.BetaTester,
@@ -518,8 +523,10 @@ func toProfileJson(profile *entities.Profile) *profileJson {
 	}
 
 	return &profileJson{
-		Address: profile.Address,
-		ENSName: profile.ENSName,
+		Address:      profile.Address,
+		Banned:       profile.Banned,
+		LastModified: profile.LastModified,
+		ENSName:      profile.ENSName,
 		StoreAssets: &storeAssetsJson{
 			Premium:    profile.StoreAssets.Premium,
 			BetaTester: profile.StoreAssets.BetaTester,

--- a/presenters/http/errors.go
+++ b/presenters/http/errors.go
@@ -24,6 +24,11 @@ func (p *httpPresenter) PresentTooManyRequests(w http.ResponseWriter, r *http.Re
 	p.presentJSON(w, r, http.StatusTooManyRequests, toErrJson("too many requests"))
 }
 
+func (p *httpPresenter) PresentForbiddenRequest(w http.ResponseWriter, r *http.Request, err error) {
+	p.logger.Info(r.Context()).Err(err).Msg("forbidden request")
+	p.presentJSON(w, r, http.StatusForbidden, toErrJson("forbidden request"))
+}
+
 func toErrJson(msg string) *errJson {
 	return &errJson{
 		Message: msg,

--- a/presenters/http/http.go
+++ b/presenters/http/http.go
@@ -64,8 +64,9 @@ func toChallengeJson(challenge *entities.Challenge) *challengeJson {
 
 func toProfileJson(profile *entities.Profile) *profileJson {
 	return &profileJson{
-		Address: profile.Address,
-		ENSName: profile.ENSName,
+		Address:      profile.Address,
+		LastModified: profile.LastModified,
+		ENSName:      profile.ENSName,
 		StoreAssets: &storeAssetsJson{
 			Premium:    profile.StoreAssets.Premium,
 			BetaTester: profile.StoreAssets.BetaTester,
@@ -309,6 +310,7 @@ type challengeJson struct {
 
 type profileJson struct {
 	Address           string                  `json:"address"`
+	LastModified      *time.Time              `json:"last_modified,omitempty"`
 	ENSName           string                  `json:"ens_name"`
 	StoreAssets       *storeAssetsJson        `json:"store_assets"`
 	DisplayConfig     *displayConfigJson      `json:"display_config,omitempty"`

--- a/presenters/presenter.go
+++ b/presenters/presenter.go
@@ -11,6 +11,7 @@ type IPresenter interface {
 	PresentUnathorized(http.ResponseWriter, *http.Request, error)
 	PresentNotFound(http.ResponseWriter, *http.Request, error)
 	PresentTooManyRequests(http.ResponseWriter, *http.Request, error)
+	PresentForbiddenRequest(http.ResponseWriter, *http.Request, error)
 	PresentHealth(http.ResponseWriter, *http.Request)
 	PresentChallenge(http.ResponseWriter, *http.Request, *entities.Challenge)
 	PresentFungibleToken(http.ResponseWriter, *http.Request, *entities.FungibleToken)

--- a/usecases/get_default_profile.go
+++ b/usecases/get_default_profile.go
@@ -70,6 +70,7 @@ func (uc *getDefaultProfileUseCase) Do(ctx context.Context, input *GetDefaultPro
 			BetaTester: false,
 		},
 		Interactions: &[]entities.Interaction{},
+		Banned:       false,
 	}
 	var wg sync.WaitGroup
 	wg.Add(6)

--- a/usecases/get_top_profiles.go
+++ b/usecases/get_top_profiles.go
@@ -63,6 +63,11 @@ func (uc *getTopProfilesUseCase) Do(ctx context.Context, input *GetTopProfilesIn
 				return
 			}
 
+			if profile.Banned {
+				uc.logger.Info(ctx).Msgf("excluding banned profile %v", address)
+				return
+			}
+
 			profiles[i] = profile
 		}(i, address)
 	}


### PR DESCRIPTION
- banned field is checked in controller and we present a 403 forbidden status code if true
- banned field is ommited from db profile update
- banned profiles are excluded from top profile results
- last modified field is set in db gateway on profile upserts
- last modified filed is included in json profile result
- last modified is excluded when nil (default profiles)