### PR TITLE
padding zeros on id replace for erc1155 uri resolution

### DIFF
--- a/profiles-api/entities/profile.go
+++ b/profiles-api/entities/profile.go
@@ -8,11 +8,11 @@ type Profile struct {
 	LastModified      *time.Time // LastModified can be nil if this is a defaul profile
 	ENSName           string
 	StoreAssets       *StoreAssets
-	DisplayConfig     *DisplayConfig    // DisplayConfig can be nil if this is a default profile
-	ProfilePicture    *NonFungibleToken // ProfilePicture can be nil if this is a default profile with no NFTs or they have simply removed their profile picture
-	NonFungibleTokens *[]NonFungibleToken
-	FungibleTokens    *[]FungibleToken
-	Statistics        *[]Statistic
-	Interactions      *[]Interaction
-	Currencies        *[]Currency
+	DisplayConfig     *DisplayConfig      // DisplayConfig can be nil if this is a default profile
+	ProfilePicture    *NonFungibleToken   // ProfilePicture can be nil if this is a default profile with no NFTs or they have simply removed their profile picture
+	NonFungibleTokens *[]NonFungibleToken // NonFungibleTokens can ve nil if this is a light hydrated profile
+	FungibleTokens    *[]FungibleToken    // FungibleTokens can ve nil if this is a light hydrated profile
+	Statistics        *[]Statistic        // Statistics can ve nil if this is a light hydrated profile
+	Interactions      *[]Interaction      // Interactions can ve nil if this is a light hydrated profile
+	Currencies        *[]Currency         // Currencies can ve nil if this is a light hydrated profile
 }

--- a/profiles-api/gateways/ethereum/nft.go
+++ b/profiles-api/gateways/ethereum/nft.go
@@ -127,9 +127,13 @@ func (gw *gateway) GetERC1155URI(ctx context.Context, contract *entities.Contrac
 		return "", fmt.Errorf("erc1155 uri %w", err)
 	}
 
-	// TODO: I think we should be padding zeros to th left hereo until 64 characters long.
-	// See https://eips.ethereum.org/EIPS/eip-1155: token ids are passed in hexidecimal form
+	// See https://eips.ethereum.org/EIPS/eip-1155
+	// token ids are passed in hexidecimal form and should be padded with zeros until 64 chars long
 	hexId := hex.EncodeToString(id.Bytes())
+	idLength := len([]rune(hexId))
+	for i := 0; i < 64-idLength; i++ {
+		hexId = "0" + hexId
+	}
 	uri = strings.Replace(uri, "{id}", hexId, 1)
 
 	return uri, nil


### PR DESCRIPTION
See https://eips.ethereum.org/EIPS/eip-1155 for notes on replacing the {id} param in the erc1155 uri response